### PR TITLE
refactor: Fix indentation in workflows and labeler files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,30 @@
+---
 root:
-  - changed-files:
-      - any-glob-to-any-file: '*'
+    - changed-files:
+          - any-glob-to-any-file: '*'
 
 AnyChange:
-  - changed-files:
-      - any-glob-to-any-file: '**'
+    - changed-files:
+          - any-glob-to-any-file: '**'
 
 Documentation:
-  - changed-files:
-      - any-glob-to-any-file: '**/*.md'
+    - changed-files:
+          - any-glob-to-any-file: '**/*.md'
 
 feature:
-  - head-branch: ['^feature', 'feature']
+    - head-branch: [^feature, feature]
 
 infrastructure:
-  - head-branch: ['^infrastructure', 'infrastructure']
-  - changed-files:
-      - any-glob-to-any-file: ['**/*.tf', '**/*.tfvars', '**/*.hcl']
+    - head-branch: [^infrastructure, infrastructure]
+    - changed-files:
+          - any-glob-to-any-file: ['**/*.tf', '**/*.tfvars', '**/*.hcl']
 
 release:
-  - base-branch: 'main'
+    - base-branch: main
 
 source:
     - changed-files:
-        - any-glob-to-any-file: '**/*.go'
+          - any-glob-to-any-file: '**/*.go'
 ci/cd:
-  - changed-files:
-      - any-glob-to-any-file: ['**/.github/workflows/*', '**/.gitlab-ci.yml']
+    - changed-files:
+          - any-glob-to-any-file: ['**/.github/workflows/*', '**/.gitlab-ci.yml']

--- a/.github/workflows/labels-assigner.yml
+++ b/.github/workflows/labels-assigner.yml
@@ -7,8 +7,8 @@ defaults:
     run:
         shell: bash
 permissions:
-  contents: read
-  pull-requests: write
+    contents: read
+    pull-requests: write
 jobs:
     triage:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
           - id: yamlfmt
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
+      rev: v4.6.0
       hooks:
           - id: trailing-whitespace
           - id: check-added-large-files
@@ -61,7 +61,7 @@ repos:
             args: [--fix, .]
 
     - repo: https://github.com/tcort/markdown-link-check
-      rev: v3.11.2
+      rev: v3.12.1
       hooks:
           - id: markdown-link-check
             args:


### PR DESCRIPTION
Update the indentation in .github/workflows/labels-assigner.yml
and .github/labeler.yml for better readability and consistency. Also,
upgrade markdown-link-check and pre-commit-hooks versions in
.pre-commit-config.yaml to v3.12.1 and v4.6.0 respectively.