### PR TITLE
feat: Update .gitignore to exclude go.work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 *.so
 *.dylib
 
-# Test binary, built with `go test-data -c`
-*.test
-
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.out.tmp
@@ -43,3 +40,4 @@
 /dagger.gen.go
 /internal/dagger
 /internal/querybuilder
+go.work


### PR DESCRIPTION
Removed unnecessary entries from .gitignore and added go.work to exclude generated files.