### PR TITLE
feat: Refactor RunAll method in Terragrunt struct

### DIFF
--- a/terragrunt/dagger/daggerx.go
+++ b/terragrunt/dagger/daggerx.go
@@ -60,3 +60,7 @@ func toEnvVarsDagger(envVarSlice []string) ([]EnvVarDagger, error) {
 
 	return envVars, nil
 }
+
+func convertCMDToString(cmd []string) string {
+	return strings.Join(cmd, " ")
+}

--- a/terragrunt/dagger/main.go
+++ b/terragrunt/dagger/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 )
 
 const (
@@ -143,33 +144,47 @@ func (m *Terragrunt) Run(
 	return out, err
 }
 
-//// RunAll executes any Terragrunt run-all command.
-//func (m *Terragrunt) RunAll(
-//	// module is the terragunt module to use that includes the terragrunt.hcl
-//	// the module should be relative to the mounted directory (--src).
-//	module string,
-//	// cmd is the command to run.
-//	cmd string,
-//	// envVars is the list of environment variables to pass from the host to the container.
-//	// the format of the environment variables passed from the host are slices of strings separted by "=", and commas.
-//	// E.g., []string{"HOST=localhost", "PORT=8080"}
-//	// +optional
-//	// +default=[]
-//	envVars []string,
-//	// args is the list of arguments to pass to the Terragrunt command.
-//	// +optional
-//	args string,
-//) (string, error) {
-//	runAllCMD := fmt.Sprintf("run-all %s", cmd)
-//	nonInteractive := "--terragrunt-non-interactive"
-//	allArgs := fmt.Sprintf("%s %s", nonInteractive, args)
-//	tgCMD, err := m.AddCMD(module, runAllCMD, envVars, allArgs)
-//	if err != nil {
-//		return "", err
-//	}
-//
-//	out, err := tgCMD.Ctr.
-//		Stdout(context.Background())
-//
-//	return out, err
-//}
+// RunAll executes any Terragrunt run-all command.
+func (m *Terragrunt) RunAll(
+	// module is the terragunt module to use that includes the terragrunt.hcl
+	// the module should be relative to the mounted directory (--src).
+	module string,
+	// cmd is the command to run.
+	cmd string,
+	// envVars is the list of environment variables to pass from the host to the container.
+	// the format of the environment variables passed from the host are slices of strings separted by "=", and commas.
+	// E.g., []string{"HOST=localhost", "PORT=8080"}
+	// +optional
+	// +default=[]
+	envVars []string,
+	// args is the list of arguments to pass to the Terragrunt command.
+	// +optional
+	args string,
+) (string, error) {
+	runAllCMD := fmt.Sprintf("run-all %s", cmd)
+	nonInteractive := "--terragrunt-non-interactive"
+	allArgs := fmt.Sprintf("%s %s", nonInteractive, args)
+
+	fullCMD := append([]string{entrypointCMD, runAllCMD}, buildArgs(allArgs)...)
+	fullCMDAsStr := convertCMDToString(fullCMD)
+
+	// Add the terragrunt module as the workdir.
+	m.Ctr = m.WithSource(m.Src, module).Ctr
+
+	// Add the environment variables to the container.
+	envVarsDaggerFormat, err := toEnvVarsDagger(envVars)
+	if err != nil {
+		return "", err
+	}
+
+	m.Ctr = m.WithEnvVars(envVarsDaggerFormat).Ctr
+
+	out, err := m.Ctr.
+		WithEntrypoint(nil).
+		// Somehow the run-all command is not working with the entrypoint, so I'm using the full command as a string.
+		// and running it with the shell.
+		WithExec([]string{"sh", "-c", fullCMDAsStr}).
+		Stdout(context.Background())
+
+	return out, err
+}


### PR DESCRIPTION
Refactored the RunAll method in the Terragrunt struct to simplify the command
execution process. Introduced a new function `convertCMDToString` to convert
command slices to strings. Modified the method to use the full command as a string
and run it with the shell due to issues with the entrypoint. Added conversion of
environment variables to Dagger format for passing to the container.