### PR TITLE
doc: Add module template structure with tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,47 @@ just create <module-name>
 just cilocal <module-name>
 ```
 
+A new module will be generated with the following structure, with already included **tests** and **examples** (for now, only Go examples):
+
+```bash
+ tre module-template 
+module-template
+├── .gitattributes
+├── .gitignore
+├── LICENSE
+├── README.md
+├── apis.go
+├── cloud.go
+├── commands.go
+├── common.go
+├── config.go
+├── dagger.json
+├── examples
+│   └── go
+│       ├── .gitattributes
+│       ├── .gitignore
+│       ├── dagger.json
+│       ├── go.mod
+│       ├── go.sum
+│       ├── main.go
+│       └── testdata
+│           └── common
+│               ├── README.md
+│               └── test-file.yml
+├── go.mod
+├── go.sum
+├── main.go
+└── tests
+    ├── .gitattributes
+    ├── .gitignore
+    ├── dagger.json
+    ├── go.mod
+    ├── go.sum
+    ├── main.go
+    └── testdata
+        └── common
+            ├── README.md
+            └── test-file.yml
+```
+
 >**NOTE**: See the [Module Template](./module-template) for more information for the new module structure, and the boilerplate code that's generated.


### PR DESCRIPTION
This commit introduces a new module template that generates a standardized structure for new Dagger modules. The template includes:

- Preconfigured .gitattributes and .gitignore files
- LICENSE file
- README.md
- Go source files (apis.go, cloud.go, commands.go, common.go, config.go, main.go)
- dagger.json file
- Example Go code in the `examples/go` directory
- Test suite in the `tests` directory

The goal of this change is to provide a consistent starting point for new module development, making it easier to get up and running quickly with a tested, well-structured codebase.