### PR TITLE
ci: Add GitHub workflow to bump Dagger module versions

### DIFF
--- a/.github/workflows/bump-dagger-module-versions.yml
+++ b/.github/workflows/bump-dagger-module-versions.yml
@@ -1,0 +1,74 @@
+---
+name: Bump Dagger Module Versions 🚀
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  detect-modules:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      changed_modules: ${{ steps.set-modules.outputs.changed_modules }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+
+      - name: Detect changed modules
+        id: set-modules
+        run: |
+          modules=()
+          for dir in $(find . -type f -name dagger.json -exec dirname {} \;); do
+            if git diff --name-only HEAD~1 HEAD -- $dir/ | grep -q .; then
+              modules+=($dir)
+            fi
+          done
+          changed_modules=$(IFS=,; echo "${modules[*]}")
+          echo "changed_modules=$changed_modules" >> $GITHUB_OUTPUT
+
+  bump-version:
+    needs: detect-modules
+    if: needs.detect-modules.outputs.changed_modules != ''
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(needs.detect-modules.outputs.changed_modules) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Semver Tool
+        run: |
+          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+          sudo cp semver-tool-master/src/semver /usr/local/bin/
+
+      - name: Bump Version and Tag
+        run: |
+          module_path="${{ matrix.module }}"
+          latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
+          current_version=$(echo $latest_tag | sed 's|${module_path}/v||')
+          new_version="v$(semver bump ${bump} "v$current_version")"
+          new_tag="${module_path}/$new_version"
+          if git rev-parse "$new_tag" >/dev/null 2>&1; then
+              echo "Tag $new_tag already exists, skipping tag creation"
+          else
+              git tag -a "$new_tag" -m "Bump $module_path to $new_version"
+              git push origin "$new_tag"
+          fi
+        env:
+          bump: ${{ inputs.bump || 'minor' }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Cargo.lock
 /.daggerx/daggy/target/
 .aider*
 /internal/telemetry
+
+.idea


### PR DESCRIPTION
This commit adds a new GitHub workflow that automatically detects changes in Dagger modules and bumps the version tags accordingly. The workflow is triggered when a pull request is merged into the main branch, or manually through the workflow dispatch.

The key changes are:

- Added a new GitHub workflow file `.github/workflows/bump-dagger-module-versions.yml`
- The workflow detects changes in Dagger modules by checking for modified `dagger.json` files
- It then bumps the version tag (major, minor, or patch) for the changed modules and pushes the new tag to the repository