### PR TITLE
feat: Clone Git repository with optional VCS

### DIFF
--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -299,7 +299,6 @@ func (m *ModuleTemplate) WithClonedGitRepo(
 	// +optional
 	vcs string,
 ) *ModuleTemplate {
-	// Call the helper function to clone the repository.
 	clonedRepo := m.CloneGitRepo(repoURL, token, vcs)
 
 	// Mount the cloned repository as a directory inside the container.


### PR DESCRIPTION
Adds a new method `WithClonedGitRepo` to the `ModuleTemplate` struct to clone a Git repository with an optional version control system (VCS). This method calls the `CloneGitRepo` helper function to perform the actual cloning operation.