### PR TITLE
ci: Bump Dagger module versions on pull request close or manual trigger

### DIFF
--- a/.github/workflows/bump-dagger-module-versions.yml
+++ b/.github/workflows/bump-dagger-module-versions.yml
@@ -4,10 +4,12 @@ name: Bump Dagger Module Versions 🚀
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
+    # branches:
+    #   - main
   workflow_dispatch:
-
+  push:
+    branches:
+      - '**'
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
- Expanded the trigger for the workflow to include the `push` event on any branch
- Removed the specific branch restriction for the `pull_request` event, allowing the workflow to run on any pull request
- Updated the workflow permissions to grant write access to both `contents` and `pull-requests`