### PR TITLE
feat: Expand trigger conditions for module version bump workflow

### DIFF
--- a/.github/workflows/bump-dagger-module-versions.yml
+++ b/.github/workflows/bump-dagger-module-versions.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   detect-modules:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       changed_modules: ${{ steps.set-modules.outputs.changed_modules }}


### PR DESCRIPTION
The changes in this commit expand the trigger conditions for the "detect-modules" job
in the "bump-dagger-module-versions.yml" GitHub Actions workflow. The job will now
run not only when a pull request is merged, but also when a workflow is manually
triggered or when a push event occurs. This allows the workflow to be run more
flexibly, ensuring that module versions are updated as needed.