### PR TITLE
ci: Improve Dagger module version bumping workflow

### DIFF
--- a/.github/workflows/bump-dagger-module-versions.yml
+++ b/.github/workflows/bump-dagger-module-versions.yml
@@ -1,4 +1,3 @@
----
 name: Bump Dagger Module Versions 🚀
 
 on:
@@ -61,9 +60,6 @@ jobs:
     needs: detect-modules
     if: needs.detect-modules.outputs.changed_modules != '[]'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        module: ${{ fromJson(needs.detect-modules.outputs.changed_modules) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,17 +72,24 @@ jobs:
 
       - name: Bump Version and Tag
         run: |
-          module_path="${{ matrix.module }}"
-          latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
-          current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
-          new_version="v$(semver bump ${bump} "v$current_version")"
-          new_tag="${module_path}/$new_version"
-          if git rev-parse "$new_tag" >/dev/null 2>&1; then
-              echo "::warning::Tag $new_tag already exists, skipping tag creation"
-          else
-              git tag -a "$new_tag" -m "Bump $module_path to $new_version"
-              git push origin "$new_tag"
-              echo "::notice::New version bumped to $new_version and tagged as $new_tag"
+          changed_modules='${{ needs.detect-modules.outputs.changed_modules }}'
+          if [ "$changed_modules" == "[]" ]; then
+            echo "::notice::No changes detected in any modules. Skipping version bump."
+            exit 0
           fi
+
+          echo "$changed_modules" | jq -r '.[]' | while read -r module_path; do
+            latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
+            current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
+            new_version="v$(semver bump ${bump} "v$current_version")"
+            new_tag="${module_path}/$new_version"
+            if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                echo "::warning::Tag $new_tag already exists, skipping tag creation"
+            else
+                git tag -a "$new_tag" -m "Bump $module_path to $new_version"
+                git push origin "$new_tag"
+                echo "::notice::New version bumped to $new_version and tagged as $new_tag"
+            fi
+          done
         env:
           bump: ${{ inputs.bump || 'minor' }}


### PR DESCRIPTION
The changes in this commit improve the Dagger module version bumping workflow:

- Remove the `strategy` matrix for the `module` input, as it's not necessary since the `changed_modules` output is already a list.
- Iterate over the list of changed modules and bump the version and create the tag for each one separately, instead of using a matrix.
- Add a check to skip the workflow if no modules have changed.
- Improve the output messages to be more informative.