### PR TITLE
feat: Implement automated publishing for Dagger modules

### DIFF
--- a/.github/workflows/publish-dagger-modules.yml
+++ b/.github/workflows/publish-dagger-modules.yml
@@ -1,0 +1,79 @@
+---
+name: Publish Dagger Modules 🚀
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*/v*.*.*'
+
+env:
+  GO_VERSION: ~1.22
+  DAG_VERSION: 0.12.4
+
+jobs:
+  detect-and-publish-modules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+
+      - name: Identify modules to publish
+        id: identify-modules
+        run: |
+          all_modules=()
+          while IFS= read -r -d '' dir; do
+            if [[ -f "$dir/dagger.json" ]]; then
+              module_name="${dir#./}"
+              all_modules+=("$module_name")
+            fi
+          done < <(find . -maxdepth 1 -type d -print0)
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            tag="${{ github.ref_name }}"
+            module_from_tag=$(echo "$tag" | cut -d'/' -f1)
+            version_from_tag=$(echo "$tag" | cut -d'/' -f2)
+            if [[ " ${all_modules[*]} " =~ " ${module_from_tag} " ]]; then
+              modules_to_publish=("$module_from_tag")
+            else
+              modules_to_publish=()
+            fi
+          else
+            modules_to_publish=("${all_modules[@]}")
+          fi
+
+          json_modules=$(printf '%s\n' "${modules_to_publish[@]}" | jq -R . | jq -sc)
+          echo "modules_to_publish=$json_modules" >> $GITHUB_OUTPUT
+          echo "Modules to publish: $json_modules"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Publish modules
+        env:
+          MODULES: ${{ steps.identify-modules.outputs.modules_to_publish }}
+        run: |
+          echo "$MODULES" | jq -r '.[]' | while read -r module; do
+            echo "Publishing module: $module"
+            dagger_version=$(jq -r '.sdk' "$module/dagger.json")
+            dagger_version=${dagger_version:-$DAG_VERSION}
+
+            echo "Developing module $module with Dagger $dagger_version"
+            dagger -m $module develop --sdk $dagger_version --cloud-token ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+            echo "Publishing $module to Daggerverse"
+            dagger -m $module publish --sdk $dagger_version --cloud-token ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          done
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Failed to publish one or more modules. Please check the logs for details."


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automates the publishing of Dagger modules to the Daggerverse. The key changes are:

- Add a new GitHub Actions workflow file `.github/workflows/publish-dagger-modules.yml` that is triggered on the creation of a new tag matching the pattern `*/v*.*.*`.
- The workflow detects all Dagger modules in the repository by searching for directories containing a `dagger.json` file.
- If the workflow is triggered by a tag push, it will only publish the module associated with the tag. Otherwise, it will publish all detected modules.
- The workflow sets up the required Go environment and uses the Dagger CLI to develop and publish the identified modules to the Daggerverse.
- The workflow includes a failure notification step to inform the repository maintainers if any issues occur during the publishing process.