### PR TITLE
feat: Update Dagger CLI and publication workflow

### DIFF
--- a/.github/workflows/publish-dagger-modules.yml
+++ b/.github/workflows/publish-dagger-modules.yml
@@ -24,6 +24,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install jq
 
+      - name: Install Dagger CLI
+        run: |
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+          sudo mv bin/dagger /usr/local/bin/
+          dagger version
+          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+            echo "Installed Dagger version does not match DAG_VERSION"
+            exit 1
+          fi
+
       - name: Identify modules to publish
         id: identify-modules
         run: |
@@ -71,15 +81,10 @@ jobs:
             dagger_version=${dagger_version:-$DAG_VERSION}
 
             echo "Developing module $module with Dagger $dagger_version"
-            dagger -m $module develop --sdk $dagger_version --cloud-token ${{ secrets.DAGGER_CLOUD_TOKEN }}
+            dagger -m $module develop --cloud-token ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
             echo "Publishing $module to Daggerverse"
-            uses: dagger/dagger-for-github@v6
-            with:
-              verb: publish
-              module: $module
-              version: $dagger_version
-              cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+            dagger -m $module publish --cloud-token ${{ secrets.DAGGER_CLOUD_TOKEN }}
           done
 
       - name: Notify on failure


### PR DESCRIPTION
- Change Dagger CLI installation to use the provided `DAG_VERSION` environment variable
- Remove the use of the GitHub action for publishing Dagger modules and use the Dagger CLI directly instead
- Ensure the installed Dagger CLI version matches the `DAG_VERSION` environment variable to prevent potential version mismatches