### PR TITLE
ci: Add new workflow to publish and bump Dagger modules

### DIFF
--- a/.github/workflows/bump_and_publish_manual.yml
+++ b/.github/workflows/bump_and_publish_manual.yml
@@ -1,0 +1,111 @@
+---
+name: Publish and Bump Dagger Modules 🚀
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to publish (or "all" for all modules)'
+        required: true
+        default: 'all'
+      bump:
+        description: 'Version bump type (major, minor, patch)'
+        required: true
+        default: 'minor'
+
+env:
+  GO_VERSION: ~1.22
+  DAG_VERSION: 0.12.4
+
+jobs:
+  publish-and-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+          sudo cp semver-tool-master/src/semver /usr/local/bin/
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+          sudo mv bin/dagger /usr/local/bin/
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Identify all modules
+        id: identify-modules
+        run: |
+          all_modules=()
+          while IFS= read -r -d '' dir; do
+            if [[ -f "$dir/dagger.json" ]]; then
+              all_modules+=("${dir#./}")
+            fi
+          done < <(find . -maxdepth 1 -type d -print0)
+          echo "All identified modules: ${all_modules[*]}"
+          echo "all_modules=${all_modules[*]}" >> $GITHUB_OUTPUT
+
+      - name: Validate and set target modules
+        id: set-target-modules
+        run: |
+          all_modules=(${{ steps.identify-modules.outputs.all_modules }})
+          input_module="${{ github.event.inputs.module }}"
+          if [[ "$input_module" == "all" ]]; then
+            target_modules=("${all_modules[@]}")
+          elif [[ " ${all_modules[*]} " =~ " ${input_module} " ]]; then
+            target_modules=("$input_module")
+          else
+            echo "::error::Invalid module name: $input_module"
+            exit 1
+          fi
+          echo "Target modules: ${target_modules[*]}"
+          echo "target_modules=${target_modules[*]}" >> $GITHUB_OUTPUT
+
+      - name: Process modules
+        env:
+          TARGET_MODULES: ${{ steps.set-target-modules.outputs.target_modules }}
+        run: |
+          for module in $TARGET_MODULES; do
+            echo "Processing module: $module"
+
+            # Check for changes
+            if ! git diff --quiet HEAD~1 HEAD -- "$module/"; then
+              echo "Changes detected in $module. Proceeding with version bump and publish."
+
+              # Get latest tag and bump version
+              latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
+              current_version=$(echo $latest_tag | sed "s|${module}/v||")
+              new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
+              new_tag="${module}/$new_version"
+
+              if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                echo "::warning::Tag $new_tag already exists, skipping version bump and publish for $module"
+              else
+                # Create and push new tag
+                git tag -a "$new_tag" -m "Bump $module to $new_version"
+                git push origin "$new_tag"
+                echo "::notice::New version bumped to $new_version and tagged as $new_tag for $module"
+
+                # Publish to Daggerverse
+                echo "Publishing $module to Daggerverse"
+                git checkout "refs/tags/$new_tag"
+                dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${new_version}
+                git checkout -
+                echo "::notice::Successfully published $module version $new_version to Daggerverse"
+              fi
+            else
+              echo "::notice::No changes detected in $module. Skipping."
+            fi
+          done
+
+      - name: Notify on completion
+        run: |
+          echo "::notice::Module processing completed. Check logs for details on each module's status."
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Failed to process one or more modules. Please check the logs for details."

--- a/.github/workflows/publish-dagger-modules.yml
+++ b/.github/workflows/publish-dagger-modules.yml
@@ -1,3 +1,4 @@
+---
 name: Publish Dagger Modules 🚀
 
 on:


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow named "Publish and Bump Dagger Modules" that allows manually triggering the publication and version bump of Dagger modules.

The key changes include:

- Add a new workflow file `.github/workflows/bump_and_publish_manual.yml` to handle the manual publication and version bump of Dagger modules.
- The workflow is triggered manually using the `workflow_dispatch` event.
- It identifies all Dagger modules in the repository, validates the user-provided module input, and processes the target modules.
- For each target module, it checks if there are changes, retrieves the latest tag, bumps the version based on the user input, creates and pushes a new tag, and publishes the module to the Daggerverse.
- The workflow provides appropriate feedback and error handling throughout the process.