### PR TITLE
feat: Rename GitHub Actions workflow file for better consistency

### DIFF
--- a/.daggerx/daggy/src/main.rs
+++ b/.daggerx/daggy/src/main.rs
@@ -484,7 +484,7 @@ fn get_module_configurations(module: &str) -> Result<NewDaggerModule, Error> {
         module_test_src_path: module_path_full.join("tests").to_string_lossy().to_string(),
         name: module.to_string(),
         github_actions_workflow_path: current_root_dir.join(".github/workflows").to_string_lossy().to_string(),
-        github_actions_workflow: current_root_dir.join(".github/workflows").join(format!("mod-{}-ci.yaml", module)).to_string_lossy().to_string(),
+        github_actions_workflow: current_root_dir.join(".github/workflows").join(format!("ci-mod-{}.yaml", module)).to_string_lossy().to_string(),
     })
 }
 


### PR DESCRIPTION
The commit renames the GitHub Actions workflow file for each module from `mod-{module}-ci.yaml` to `ci-mod-{module}.yaml`. This change improves the consistency of the workflow file naming convention.