### PR TITLE
feat: Add Dagger CI workflow for module-template

### DIFF
--- a/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
+++ b/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-name: {{.module_name_pkg}} CI 🧹
+name: CI {{.module_name_pkg}} 🧹
 on:
     push:
         branches:

--- a/.github/workflows/cd-bump-dag-module-version.yml
+++ b/.github/workflows/cd-bump-dag-module-version.yml
@@ -2,108 +2,108 @@
 name: CD Bump Dagger Module Versions 🏷️
 
 on:
-  pull_request:
-    types: [closed]
-  workflow_dispatch:
+    pull_request:
+        types: [closed]
+    workflow_dispatch:
 #  Only for torubleshooting purposes, uncomment the following lines
 #  push:
 #    branches:
 #      - '**'
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  detect-modules:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      changed_modules: ${{ steps.set-modules.outputs.changed_modules }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    detect-modules:
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'push'
+        runs-on: ubuntu-latest
+        outputs:
+            changed_modules: ${{ steps.set-modules.outputs.changed_modules }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
+            - name: Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
 
-      - name: Identify all modules
-        id: identify-modules
-        run: |
-          modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: Identify all modules
+              id: identify-modules
+              run: |
+                  modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          all_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
-          echo "all_modules=$all_modules" >> $GITHUB_OUTPUT
-          echo "All identified modules: $all_modules"
+                  all_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
+                  echo "all_modules=$all_modules" >> $GITHUB_OUTPUT
+                  echo "All identified modules: $all_modules"
 
-      - name: Detect changed modules
-        id: set-modules
-        run: |
-          modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]] && git diff --name-only HEAD~1 HEAD -- "$dir/" | grep -q .; then
-              modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: Detect changed modules
+              id: set-modules
+              run: |
+                  modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]] && git diff --name-only HEAD~1 HEAD -- "$dir/" | grep -q .; then
+                      modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          changed_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
-          echo "changed_modules=$changed_modules" >> $GITHUB_OUTPUT
-          echo "Modules with changes: $changed_modules"
+                  changed_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
+                  echo "changed_modules=$changed_modules" >> $GITHUB_OUTPUT
+                  echo "Modules with changes: $changed_modules"
 
-  bump-version:
-    needs: detect-modules
-    if: needs.detect-modules.outputs.changed_modules != '[]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+    bump-version:
+        needs: detect-modules
+        if: needs.detect-modules.outputs.changed_modules != '[]'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Semver Tool
-        run: |
-          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
-          sudo cp semver-tool-master/src/semver /usr/local/bin/
+            - name: Setup Semver Tool
+              run: |
+                  curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+                  sudo cp semver-tool-master/src/semver /usr/local/bin/
 
-      - name: Configure Git
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            - name: Configure Git
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Bump Version and Tag
-        run: |
-          changed_modules='${{ needs.detect-modules.outputs.changed_modules }}'
-          if [ "$changed_modules" == "[]" ] || [ "$changed_modules" == '[""]' ]; then
-            echo "::notice::No changes detected in any modules. Skipping version bump."
-            exit 0
-          fi
+            - name: Bump Version and Tag
+              run: |
+                  changed_modules='${{ needs.detect-modules.outputs.changed_modules }}'
+                  if [ "$changed_modules" == "[]" ] || [ "$changed_modules" == '[""]' ]; then
+                    echo "::notice::No changes detected in any modules. Skipping version bump."
+                    exit 0
+                  fi
 
-          echo "$changed_modules" | jq -r '.[]' | while read -r module_path; do
-            if [ -z "$module_path" ]; then
-              echo "::warning::Empty module path detected. Skipping."
-              continue
-            fi
+                  echo "$changed_modules" | jq -r '.[]' | while read -r module_path; do
+                    if [ -z "$module_path" ]; then
+                      echo "::warning::Empty module path detected. Skipping."
+                      continue
+                    fi
 
-            latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
-            current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
-            new_version="v$(semver bump ${bump} "v$current_version")"
-            new_tag="${module_path}/$new_version"
-            if git rev-parse "$new_tag" >/dev/null 2>&1; then
-                echo "::warning::Tag $new_tag already exists, skipping tag creation"
-            else
-                git tag -a "$new_tag" -m "Bump $module_path to $new_version"
-                git push origin "$new_tag"
-                echo "::notice::New version bumped to $new_version and tagged as $new_tag"
-            fi
-          done
-        env:
-          bump: ${{ inputs.bump || 'minor' }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
+                    current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
+                    new_version="v$(semver bump ${bump} "v$current_version")"
+                    new_tag="${module_path}/$new_version"
+                    if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                        echo "::warning::Tag $new_tag already exists, skipping tag creation"
+                    else
+                        git tag -a "$new_tag" -m "Bump $module_path to $new_version"
+                        git push origin "$new_tag"
+                        echo "::notice::New version bumped to $new_version and tagged as $new_tag"
+                    fi
+                  done
+              env:
+                  bump: ${{ inputs.bump || 'minor' }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-bump-publish-dag-manual.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual.yml
@@ -2,110 +2,110 @@
 name: CD Bump and Publish Dagger Modules 🚀
 
 on:
-  workflow_dispatch:
-    inputs:
-      module:
-        description: 'Module to publish (or "all" for all modules)'
-        required: true
-        default: 'all'
-      bump:
-        description: 'Version bump type (major, minor, patch)'
-        required: true
-        default: 'minor'
+    workflow_dispatch:
+        inputs:
+            module:
+                description: Module to publish (or "all" for all modules)
+                required: true
+                default: all
+            bump:
+                description: Version bump type (major, minor, patch)
+                required: true
+                default: minor
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 jobs:
-  publish-and-bump:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    publish-and-bump:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
-          sudo cp semver-tool-master/src/semver /usr/local/bin/
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            - name: Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+                  sudo cp semver-tool-master/src/semver /usr/local/bin/
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Identify all modules
-        id: identify-modules
-        run: |
-          all_modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              all_modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
-          echo "All identified modules: ${all_modules[*]}"
-          echo "all_modules=${all_modules[*]}" >> $GITHUB_OUTPUT
+            - name: Identify all modules
+              id: identify-modules
+              run: |
+                  all_modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      all_modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
+                  echo "All identified modules: ${all_modules[*]}"
+                  echo "all_modules=${all_modules[*]}" >> $GITHUB_OUTPUT
 
-      - name: Validate and set target modules
-        id: set-target-modules
-        run: |
-          all_modules=(${{ steps.identify-modules.outputs.all_modules }})
-          input_module="${{ github.event.inputs.module }}"
-          if [[ "$input_module" == "all" ]]; then
-            target_modules=("${all_modules[@]}")
-          elif [[ " ${all_modules[*]} " =~ " ${input_module} " ]]; then
-            target_modules=("$input_module")
-          else
-            echo "::error::Invalid module name: $input_module"
-            exit 1
-          fi
-          echo "Target modules: ${target_modules[*]}"
-          echo "target_modules=${target_modules[*]}" >> $GITHUB_OUTPUT
+            - name: Validate and set target modules
+              id: set-target-modules
+              run: |
+                  all_modules=(${{ steps.identify-modules.outputs.all_modules }})
+                  input_module="${{ github.event.inputs.module }}"
+                  if [[ "$input_module" == "all" ]]; then
+                    target_modules=("${all_modules[@]}")
+                  elif [[ " ${all_modules[*]} " =~ " ${input_module} " ]]; then
+                    target_modules=("$input_module")
+                  else
+                    echo "::error::Invalid module name: $input_module"
+                    exit 1
+                  fi
+                  echo "Target modules: ${target_modules[*]}"
+                  echo "target_modules=${target_modules[*]}" >> $GITHUB_OUTPUT
 
-      - name: Process modules
-        env:
-          TARGET_MODULES: ${{ steps.set-target-modules.outputs.target_modules }}
-        run: |
-          for module in $TARGET_MODULES; do
-            echo "Processing module: $module"
+            - name: Process modules
+              env:
+                  TARGET_MODULES: ${{ steps.set-target-modules.outputs.target_modules }}
+              run: |
+                  for module in $TARGET_MODULES; do
+                    echo "Processing module: $module"
 
-            # Check for changes
-            if ! git diff --quiet HEAD~1 HEAD -- "$module/"; then
-              echo "Changes detected in $module. Proceeding with version bump and publish."
+                    # Check for changes
+                    if ! git diff --quiet HEAD~1 HEAD -- "$module/"; then
+                      echo "Changes detected in $module. Proceeding with version bump and publish."
 
-              # Get latest tag and bump version
-              latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
-              current_version=$(echo $latest_tag | sed "s|${module}/v||")
-              new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
-              new_tag="${module}/$new_version"
+                      # Get latest tag and bump version
+                      latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
+                      current_version=$(echo $latest_tag | sed "s|${module}/v||")
+                      new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
+                      new_tag="${module}/$new_version"
 
-              if git rev-parse "$new_tag" >/dev/null 2>&1; then
-                echo "::warning::Tag $new_tag already exists, skipping version bump and publish for $module"
-              else
-                # Create and push new tag
-                git tag -a "$new_tag" -m "Bump $module to $new_version"
-                git push origin "$new_tag"
-                echo "::notice::New version bumped to $new_version and tagged as $new_tag for $module"
+                      if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                        echo "::warning::Tag $new_tag already exists, skipping version bump and publish for $module"
+                      else
+                        # Create and push new tag
+                        git tag -a "$new_tag" -m "Bump $module to $new_version"
+                        git push origin "$new_tag"
+                        echo "::notice::New version bumped to $new_version and tagged as $new_tag for $module"
 
-                # Publish to Daggerverse
-                echo "Publishing $module to Daggerverse"
-                git checkout "refs/tags/$new_tag"
-                dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${new_version}
-                git checkout -
-                echo "::notice::Successfully published $module version $new_version to Daggerverse"
-              fi
-            else
-              echo "::notice::No changes detected in $module. Skipping."
-            fi
-          done
+                        # Publish to Daggerverse
+                        echo "Publishing $module to Daggerverse"
+                        git checkout "refs/tags/$new_tag"
+                        dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${new_version}
+                        git checkout -
+                        echo "::notice::Successfully published $module version $new_version to Daggerverse"
+                      fi
+                    else
+                      echo "::notice::No changes detected in $module. Skipping."
+                    fi
+                  done
 
-      - name: Notify on completion
-        run: |
-          echo "::notice::Module processing completed. Check logs for details on each module's status."
+            - name: Notify on completion
+              run: |
+                  echo "::notice::Module processing completed. Check logs for details on each module's status."
 
-      - name: Notify on failure
-        if: failure()
-        run: |
-          echo "::error::Failed to process one or more modules. Please check the logs for details."
+            - name: Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::Failed to process one or more modules. Please check the logs for details."

--- a/.github/workflows/cd-publish-dag-modules.yml
+++ b/.github/workflows/cd-publish-dag-modules.yml
@@ -2,91 +2,91 @@
 name: CD Publish Dagger Modules 🚀
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-      - '*/v*.*.*'
+    workflow_dispatch:
+    push:
+        tags:
+            - '*/v*.*.*'
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 jobs:
-  detect-and-publish-modules:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    detect-and-publish-modules:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
+            - name: Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
 
-      - name: Install Dagger CLI
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          dagger version
-          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
-            echo "Installed Dagger version does not match DAG_VERSION"
-            exit 1
-          fi
+            - name: Install Dagger CLI
+              run: |
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  dagger version
+                  if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+                    echo "Installed Dagger version does not match DAG_VERSION"
+                    exit 1
+                  fi
 
-      - name: Identify modules to publish
-        id: identify-modules
-        run: |
-          all_modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              module_name="${dir#./}"
-              all_modules+=("$module_name")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: Identify modules to publish
+              id: identify-modules
+              run: |
+                  all_modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      module_name="${dir#./}"
+                      all_modules+=("$module_name")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          modules_to_publish=()
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            tag="${{ github.ref_name }}"
-            module_from_tag=$(echo "$tag" | cut -d'/' -f1)
-            version_from_tag=$(echo "$tag" | cut -d'/' -f2-)
-            if [[ " ${all_modules[*]} " =~ " ${module_from_tag} " ]]; then
-              modules_to_publish+=("$module_from_tag:$version_from_tag")
-            fi
-          else
-            for module in "${all_modules[@]}"; do
-              latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "")
-              if [[ $latest_tag =~ ^${module}/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                version=${latest_tag#${module}/}
-                modules_to_publish+=("$module:$version")
-              fi
-            done
-          fi
+                  modules_to_publish=()
+                  if [[ "${{ github.event_name }}" == "push" ]]; then
+                    tag="${{ github.ref_name }}"
+                    module_from_tag=$(echo "$tag" | cut -d'/' -f1)
+                    version_from_tag=$(echo "$tag" | cut -d'/' -f2-)
+                    if [[ " ${all_modules[*]} " =~ " ${module_from_tag} " ]]; then
+                      modules_to_publish+=("$module_from_tag:$version_from_tag")
+                    fi
+                  else
+                    for module in "${all_modules[@]}"; do
+                      latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "")
+                      if [[ $latest_tag =~ ^${module}/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                        version=${latest_tag#${module}/}
+                        modules_to_publish+=("$module:$version")
+                      fi
+                    done
+                  fi
 
-          json_modules=$(printf '%s\n' "${modules_to_publish[@]}" | jq -R . | jq -sc)
-          echo "modules_to_publish=$json_modules" >> $GITHUB_OUTPUT
-          echo "Modules to publish: $json_modules"
+                  json_modules=$(printf '%s\n' "${modules_to_publish[@]}" | jq -R . | jq -sc)
+                  echo "modules_to_publish=$json_modules" >> $GITHUB_OUTPUT
+                  echo "Modules to publish: $json_modules"
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
 
-      - name: Publish modules
-        env:
-          MODULES: ${{ steps.identify-modules.outputs.modules_to_publish }}
-        run: |
-          echo "$MODULES" | jq -r '.[]' | while read -r module_info; do
-            module_name=$(echo "$module_info" | cut -d':' -f1)
-            version=$(echo "$module_info" | cut -d':' -f2)
+            - name: Publish modules
+              env:
+                  MODULES: ${{ steps.identify-modules.outputs.modules_to_publish }}
+              run: |
+                  echo "$MODULES" | jq -r '.[]' | while read -r module_info; do
+                    module_name=$(echo "$module_info" | cut -d':' -f1)
+                    version=$(echo "$module_info" | cut -d':' -f2)
 
-            echo "Publishing module: $module_name with version $version"
+                    echo "Publishing module: $module_name with version $version"
 
-            git checkout "refs/tags/${module_name}/${version}"
-            dagger publish -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version}
-          done
+                    git checkout "refs/tags/${module_name}/${version}"
+                    dagger publish -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version}
+                  done
 
-      - name: Notify on failure
-        if: failure()
-        run: |
-          echo "::error::Failed to publish one or more modules. Please check the logs for details."
+            - name: Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::Failed to publish one or more modules. Please check the logs for details."

--- a/.github/workflows/ci-module-template.yaml
+++ b/.github/workflows/ci-module-template.yaml
@@ -1,5 +1,5 @@
 ---
-name: module-template CI 🧹
+name: CI module-template 🧹
 on:
     push:
         branches:


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow for the module-template repository. The workflow includes the following tasks:

1. Lint the module-template code using Dagger:
   - Develop and call the module-template, tests, and examples/go modules with different Dagger versions.

2. Run GolangCI-Lint on the module-template code:
   - Develop the module-template using Dagger.
   - Install the latest version of golangci-lint and run it with the configuration from the repository.

The workflow is triggered on push and pull request events for the `main` and `master` branches, as well as on manual workflow dispatch. It runs on the Ubuntu-latest runner and uses the latest versions of the actions/setup-go and dagger/dagger-for-github actions.