### PR TITLE
feat: Mount cloned Git repository in container

### DIFF
--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -299,7 +299,7 @@ func (m *ModuleTemplate) WithClonedGitRepo(
 	// +optional
 	vcs string,
 ) *ModuleTemplate {
-	// Clone the repository
+	// Clone the repository and mount it
 	clonedRepo := m.CloneGitRepo(repoURL, token, vcs)
 
 	// Mount the cloned repository as a directory inside the container.


### PR DESCRIPTION
Clone the repository and mount it as a directory inside the container. This change improves the user experience by making the cloned repository accessible within the container environment.