### PR TITLE
feat: Add a GitHub Actions workflow to publish a specific Dagger module version

### DIFF
--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -1,0 +1,94 @@
+---
+name: 🎯 Publish Specific Dagger Module Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to publish'
+        required: true
+      version:
+        description: 'Version to publish (e.g., v1.2.3)'
+        required: true
+
+env:
+  GO_VERSION: ~1.22
+  DAG_VERSION: 0.12.4
+
+jobs:
+  publish-specific-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🛠️ Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+          sudo mv bin/dagger /usr/local/bin/
+          dagger version
+          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+            echo "::error::Installed Dagger version does not match DAG_VERSION"
+            exit 1
+          fi
+
+      - name: 🔍 Validate inputs
+        id: validate-inputs
+        run: |
+          module="${{ github.event.inputs.module }}"
+          version="${{ github.event.inputs.version }}"
+
+          if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
+            echo "::error::Invalid module: $module"
+            exit 1
+          fi
+
+          if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $version. Expected format: vX.Y.Z"
+            exit 1
+          fi
+
+          echo "module=$module" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "::notice::Inputs validated. Module: $module, Version: $version"
+
+      - name: 🏷️ Check tag existence
+        id: check-tag
+        run: |
+          module=${{ steps.validate-inputs.outputs.module }}
+          version=${{ steps.validate-inputs.outputs.version }}
+          tag="$module/$version"
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "::notice::Tag $tag exists. Proceeding with publication."
+            echo "tag_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Tag $tag does not exist. Cannot publish non-existent version."
+            exit 1
+          fi
+
+      - name: 🚀 Publish to Daggerverse
+        if: steps.check-tag.outputs.tag_exists == 'true'
+        run: |
+          module=${{ steps.validate-inputs.outputs.module }}
+          version=${{ steps.validate-inputs.outputs.version }}
+          tag="$module/$version"
+
+          echo "Publishing $module version $version to Daggerverse"
+          git checkout "refs/tags/$tag"
+          dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version}
+          git checkout -
+          echo "::notice::Successfully published $module version $version to Daggerverse"
+
+      - name: 🎉 Notify on completion
+        run: |
+          echo "::notice::Module publication process completed. Check logs for details."
+
+      - name: ❌ Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Failed to publish the module. Please check the logs for details."


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow named "🎯 Publish Specific Dagger Module Version" that allows you to publish a specific version of a Dagger module to the Daggerverse.

The workflow is triggered by a manual workflow dispatch and requires two input parameters: the module to publish and the version to publish (e.g., v1.2.3).

The key steps in the workflow are:

1. Checkout the code repository.
2. Set up the environment by installing necessary dependencies, including the Dagger CLI.
3. Validate the input parameters to ensure the module exists and the version is in the correct format.
4. Check if the target tag (module/version) exists in the repository before proceeding with the publication.
5. Publish the module to the Daggerverse using the Dagger CLI.
6. Provide success/failure notifications upon completion of the workflow.

This workflow aims to provide a streamlined and reliable way to publish specific versions of Dagger modules, which can be useful for managing and updating the Daggerverse.