### PR TITLE
ci: Update CD workflow for manual module publishing

### DIFF
--- a/.github/workflows/cd-bump-dag-module-version.yml
+++ b/.github/workflows/cd-bump-dag-module-version.yml
@@ -2,122 +2,122 @@
 name: 🏷️ CD Bump Dagger Module Versions
 
 on:
-  workflow_dispatch:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
-      - master
+    workflow_dispatch:
+    pull_request:
+        types: [closed]
+        branches:
+            - main
+            - master
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  detect-modules:
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (github.base_ref == 'main' || github.base_ref == 'master'))
-    runs-on: ubuntu-latest
-    outputs:
-      changed_modules: ${{ steps.set-modules.outputs.changed_modules }}
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    detect-modules:
+        if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (github.base_ref == 'main' || github.base_ref == 'master'))
+        runs-on: ubuntu-latest
+        outputs:
+            changed_modules: ${{ steps.set-modules.outputs.changed_modules }}
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: 🛠️ Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          echo "✅ Environment setup complete"
+            - name: 🛠️ Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  echo "✅ Environment setup complete"
 
-      - name: 🔍 Identify all modules
-        id: identify-modules
-        run: |
-          modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: 🔍 Identify all modules
+              id: identify-modules
+              run: |
+                  modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          all_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
-          echo "all_modules=$all_modules" >> $GITHUB_OUTPUT
-          echo "📦 All identified modules: $all_modules"
+                  all_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
+                  echo "all_modules=$all_modules" >> $GITHUB_OUTPUT
+                  echo "📦 All identified modules: $all_modules"
 
-      - name: 🔎 Detect changed modules
-        id: set-modules
-        run: |
-          modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]] && git diff --name-only HEAD~1 HEAD -- "$dir/" | grep -q .; then
-              modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: 🔎 Detect changed modules
+              id: set-modules
+              run: |
+                  modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]] && git diff --name-only HEAD~1 HEAD -- "$dir/" | grep -q .; then
+                      modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          changed_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
-          echo "changed_modules=$changed_modules" >> $GITHUB_OUTPUT
-          echo "🔄 Modules with changes: $changed_modules"
+                  changed_modules=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -sc)
+                  echo "changed_modules=$changed_modules" >> $GITHUB_OUTPUT
+                  echo "🔄 Modules with changes: $changed_modules"
 
-  bump-version:
-    needs: detect-modules
-    if: needs.detect-modules.outputs.changed_modules != '[]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+    bump-version:
+        needs: detect-modules
+        if: needs.detect-modules.outputs.changed_modules != '[]'
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔧 Setup Semver Tool
-        run: |
-          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
-          sudo cp semver-tool-master/src/semver /usr/local/bin/
-          echo "✅ Semver tool installed successfully"
+            - name: 🔧 Setup Semver Tool
+              run: |
+                  curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+                  sudo cp semver-tool-master/src/semver /usr/local/bin/
+                  echo "✅ Semver tool installed successfully"
 
-      - name: 👤 Configure Git
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          echo "✅ Git configured for GitHub Actions"
+            - name: 👤 Configure Git
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  echo "✅ Git configured for GitHub Actions"
 
-      - name: 🏷️ Bump Version and Tag
-        run: |
-          changed_modules='${{ needs.detect-modules.outputs.changed_modules }}'
-          if [ "$changed_modules" == "[]" ] || [ "$changed_modules" == '[""]' ]; then
-            echo "::notice::🚫 No changes detected in any modules. Skipping version bump."
-            exit 0
-          fi
+            - name: 🏷️ Bump Version and Tag
+              run: |
+                  changed_modules='${{ needs.detect-modules.outputs.changed_modules }}'
+                  if [ "$changed_modules" == "[]" ] || [ "$changed_modules" == '[""]' ]; then
+                    echo "::notice::🚫 No changes detected in any modules. Skipping version bump."
+                    exit 0
+                  fi
 
-          echo "$changed_modules" | jq -r '.[]' | while read -r module_path; do
-            if [ -z "$module_path" ]; then
-              echo "::warning::⚠️ Empty module path detected. Skipping."
-              continue
-            fi
+                  echo "$changed_modules" | jq -r '.[]' | while read -r module_path; do
+                    if [ -z "$module_path" ]; then
+                      echo "::warning::⚠️ Empty module path detected. Skipping."
+                      continue
+                    fi
 
-            latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
-            current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
-            new_version="v$(semver bump ${bump} "v$current_version")"
-            new_tag="${module_path}/$new_version"
-          
-            if git rev-parse "$new_tag" >/dev/null 2>&1; then
-                echo "::warning::⚠️ Tag $new_tag already exists, skipping tag creation"
-            else
-                git tag -a "$new_tag" -m "Bump $module_path to $new_version"
-                git push origin "$new_tag"
-                echo "::notice::🎉 New version bumped to $new_version and tagged as $new_tag for $module_path"
-            fi
-          done
-        env:
-          bump: ${{ inputs.bump || 'minor' }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    latest_tag=$(git describe --tags --abbrev=0 --match "${module_path}/*" 2>/dev/null || echo "${module_path}/v0.0.0")
+                    current_version=$(echo $latest_tag | sed "s|${module_path}/v||")
+                    new_version="v$(semver bump ${bump} "v$current_version")"
+                    new_tag="${module_path}/$new_version"
 
-      - name: 🎉 Notify on completion
-        run: |
-          echo "::notice::✅ Version bump process completed. Check logs for details on each module's status."
+                    if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                        echo "::warning::⚠️ Tag $new_tag already exists, skipping tag creation"
+                    else
+                        git tag -a "$new_tag" -m "Bump $module_path to $new_version"
+                        git push origin "$new_tag"
+                        echo "::notice::🎉 New version bumped to $new_version and tagged as $new_tag for $module_path"
+                    fi
+                  done
+              env:
+                  bump: ${{ inputs.bump || 'minor' }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ❌ Notify on failure
-        if: failure()
-        run: |
-          echo "::error::💥 Failed to bump version for one or more modules. Please check the logs for details."
+            - name: 🎉 Notify on completion
+              run: |
+                  echo "::notice::✅ Version bump process completed. Check logs for details on each module's status."
+
+            - name: ❌ Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::💥 Failed to bump version for one or more modules. Please check the logs for details."

--- a/.github/workflows/cd-bump-publish-dag-manual.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual.yml
@@ -2,123 +2,123 @@
 name: 🚀 CD Bump and Publish Dagger Modules
 
 on:
-  workflow_dispatch:
-    inputs:
-      module:
-        description: 'Module to publish (or "all" for all modules)'
-        required: true
-        default: 'all'
-      bump:
-        description: 'Version bump type'
-        required: true
-        default: 'auto'
-        type: choice
-        options:
-          - auto
-          - patch
-          - minor
-          - major
+    workflow_dispatch:
+        inputs:
+            module:
+                description: Module to publish (or "all" for all modules)
+                required: true
+                default: all
+            bump:
+                description: Version bump type
+                required: true
+                default: auto
+                type: choice
+                options:
+                    - auto
+                    - patch
+                    - minor
+                    - major
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 jobs:
-  publish-and-bump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    publish-and-bump:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: 🛠️ Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
-          sudo cp semver-tool-master/src/semver /usr/local/bin/
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          echo "✅ Environment setup complete"
+            - name: 🛠️ Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+                  sudo cp semver-tool-master/src/semver /usr/local/bin/
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  echo "✅ Environment setup complete"
 
-      - name: 🔍 Identify all modules
-        id: identify-modules
-        run: |
-          all_modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              all_modules+=("${dir#./}")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
-          echo "📦 All identified modules: ${all_modules[*]}"
-          echo "all_modules=${all_modules[*]}" >> $GITHUB_OUTPUT
+            - name: 🔍 Identify all modules
+              id: identify-modules
+              run: |
+                  all_modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      all_modules+=("${dir#./}")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
+                  echo "📦 All identified modules: ${all_modules[*]}"
+                  echo "all_modules=${all_modules[*]}" >> $GITHUB_OUTPUT
 
-      - name: ✅ Validate and set target modules
-        id: set-target-modules
-        run: |
-          all_modules=(${{ steps.identify-modules.outputs.all_modules }})
-          input_module="${{ github.event.inputs.module }}"
-          if [[ "$input_module" == "all" ]]; then
-            target_modules=("${all_modules[@]}")
-            echo "🎯 Targeting all modules"
-          elif [[ " ${all_modules[*]} " =~ " ${input_module} " ]]; then
-            target_modules=("$input_module")
-            echo "🎯 Targeting specific module: $input_module"
-          else
-            echo "::error::❌ Invalid module name: $input_module"
-            exit 1
-          fi
-          echo "target_modules=${target_modules[*]}" >> $GITHUB_OUTPUT
+            - name: ✅ Validate and set target modules
+              id: set-target-modules
+              run: |
+                  all_modules=(${{ steps.identify-modules.outputs.all_modules }})
+                  input_module="${{ github.event.inputs.module }}"
+                  if [[ "$input_module" == "all" ]]; then
+                    target_modules=("${all_modules[@]}")
+                    echo "🎯 Targeting all modules"
+                  elif [[ " ${all_modules[*]} " =~ " ${input_module} " ]]; then
+                    target_modules=("$input_module")
+                    echo "🎯 Targeting specific module: $input_module"
+                  else
+                    echo "::error::❌ Invalid module name: $input_module"
+                    exit 1
+                  fi
+                  echo "target_modules=${target_modules[*]}" >> $GITHUB_OUTPUT
 
-      - name: 🔄 Process and publish modules
-        env:
-          TARGET_MODULES: ${{ steps.set-target-modules.outputs.target_modules }}
-        run: |
-          determine_bump_type() {
-            local current_version=$1
-            if [[ "${{ github.event.inputs.bump }}" != "auto" ]]; then
-              echo "${{ github.event.inputs.bump }}"
-            else
-              echo "minor"  # Default to 'minor' if auto is selected
-            fi
-          }
+            - name: 🔄 Process and publish modules
+              env:
+                  TARGET_MODULES: ${{ steps.set-target-modules.outputs.target_modules }}
+              run: |
+                  determine_bump_type() {
+                    local current_version=$1
+                    if [[ "${{ github.event.inputs.bump }}" != "auto" ]]; then
+                      echo "${{ github.event.inputs.bump }}"
+                    else
+                      echo "minor"  # Default to 'minor' if auto is selected
+                    fi
+                  }
 
-          for module in $TARGET_MODULES; do
-            echo "🔧 Processing module: $module"
+                  for module in $TARGET_MODULES; do
+                    echo "🔧 Processing module: $module"
 
-            latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
-            current_version=$(echo $latest_tag | sed "s|${module}/v||")
-            echo "📌 Current version: $current_version"
+                    latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
+                    current_version=$(echo $latest_tag | sed "s|${module}/v||")
+                    echo "📌 Current version: $current_version"
 
-            bump_type=$(determine_bump_type "$current_version")
-            echo "📈 Bump type: $bump_type"
+                    bump_type=$(determine_bump_type "$current_version")
+                    echo "📈 Bump type: $bump_type"
 
-            new_version="v$(semver bump $bump_type "v$current_version")"
-            new_tag="${module}/$new_version"
+                    new_version="v$(semver bump $bump_type "v$current_version")"
+                    new_tag="${module}/$new_version"
 
-            git tag -a "$new_tag" -m "Bump $module to $new_version"
-            git push origin "$new_tag"
-            echo "🏷️ New version bumped to $new_version and tagged as $new_tag for $module"
+                    git tag -a "$new_tag" -m "Bump $module to $new_version"
+                    git push origin "$new_tag"
+                    echo "🏷️ New version bumped to $new_version and tagged as $new_tag for $module"
 
-            echo "🚀 Publishing $module to Daggerverse"
-            git checkout "refs/tags/$new_tag"
-            if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${new_version}; then
-              echo "✅ Successfully published $module version $new_version to Daggerverse"
-            else
-              echo "::error::❌ Failed to publish $module version $new_version"
-              exit 1
-            fi
-            git checkout -
-          done
+                    echo "🚀 Publishing $module to Daggerverse"
+                    git checkout "refs/tags/$new_tag"
+                    if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${new_version}; then
+                      echo "✅ Successfully published $module version $new_version to Daggerverse"
+                    else
+                      echo "::error::❌ Failed to publish $module version $new_version"
+                      exit 1
+                    fi
+                    git checkout -
+                  done
 
-      - name: 🎉 Notify on completion
-        run: |
-          echo "::notice::🏁 Module processing completed. Check logs for details on each module's status."
+            - name: 🎉 Notify on completion
+              run: |
+                  echo "::notice::🏁 Module processing completed. Check logs for details on each module's status."
 
-      - name: ❌ Notify on failure
-        if: failure()
-        run: |
-          echo "::error::💥 Failed to process one or more modules. Please check the logs for details."
+            - name: ❌ Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::💥 Failed to process one or more modules. Please check the logs for details."

--- a/.github/workflows/cd-publish-dag-modules.yml
+++ b/.github/workflows/cd-publish-dag-modules.yml
@@ -2,106 +2,106 @@
 name: 🚀 CD Publish Dagger Modules
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-      - '*/v*.*.*'
+    workflow_dispatch:
+    push:
+        tags:
+            - '*/v*.*.*'
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 jobs:
-  detect-and-publish-modules:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    detect-and-publish-modules:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: 🛠️ Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          echo "🔧 Environment setup complete"
+            - name: 🛠️ Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  echo "🔧 Environment setup complete"
 
-      - name: 🐳 Install Dagger CLI
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          dagger version
-          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
-            echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
-            exit 1
-          fi
-          echo "✅ Dagger CLI installed successfully"
+            - name: 🐳 Install Dagger CLI
+              run: |
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  dagger version
+                  if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+                    echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
+                    exit 1
+                  fi
+                  echo "✅ Dagger CLI installed successfully"
 
-      - name: 🔍 Identify modules to publish
-        id: identify-modules
-        run: |
-          all_modules=()
-          while IFS= read -r -d '' dir; do
-            if [[ -f "$dir/dagger.json" ]]; then
-              module_name="${dir#./}"
-              all_modules+=("$module_name")
-            fi
-          done < <(find . -maxdepth 1 -type d -print0)
+            - name: 🔍 Identify modules to publish
+              id: identify-modules
+              run: |
+                  all_modules=()
+                  while IFS= read -r -d '' dir; do
+                    if [[ -f "$dir/dagger.json" ]]; then
+                      module_name="${dir#./}"
+                      all_modules+=("$module_name")
+                    fi
+                  done < <(find . -maxdepth 1 -type d -print0)
 
-          modules_to_publish=()
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            tag="${{ github.ref_name }}"
-            module_from_tag=$(echo "$tag" | cut -d'/' -f1)
-            version_from_tag=$(echo "$tag" | cut -d'/' -f2-)
-            if [[ " ${all_modules[*]} " =~ " ${module_from_tag} " ]]; then
-              modules_to_publish+=("$module_from_tag:$version_from_tag")
-              echo "📦 Tag push detected: Publishing $module_from_tag version $version_from_tag"
-            fi
-          else
-            for module in "${all_modules[@]}"; do
-              latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "")
-              if [[ $latest_tag =~ ^${module}/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                version=${latest_tag#${module}/}
-                modules_to_publish+=("$module:$version")
-                echo "📦 Identified for publishing: $module version $version"
-              fi
-            done
-          fi
+                  modules_to_publish=()
+                  if [[ "${{ github.event_name }}" == "push" ]]; then
+                    tag="${{ github.ref_name }}"
+                    module_from_tag=$(echo "$tag" | cut -d'/' -f1)
+                    version_from_tag=$(echo "$tag" | cut -d'/' -f2-)
+                    if [[ " ${all_modules[*]} " =~ " ${module_from_tag} " ]]; then
+                      modules_to_publish+=("$module_from_tag:$version_from_tag")
+                      echo "📦 Tag push detected: Publishing $module_from_tag version $version_from_tag"
+                    fi
+                  else
+                    for module in "${all_modules[@]}"; do
+                      latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "")
+                      if [[ $latest_tag =~ ^${module}/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                        version=${latest_tag#${module}/}
+                        modules_to_publish+=("$module:$version")
+                        echo "📦 Identified for publishing: $module version $version"
+                      fi
+                    done
+                  fi
 
-          json_modules=$(printf '%s\n' "${modules_to_publish[@]}" | jq -R . | jq -sc)
-          echo "modules_to_publish=$json_modules" >> $GITHUB_OUTPUT
-          echo "🔢 Total modules to publish: $(echo $json_modules | jq length)"
+                  json_modules=$(printf '%s\n' "${modules_to_publish[@]}" | jq -R . | jq -sc)
+                  echo "modules_to_publish=$json_modules" >> $GITHUB_OUTPUT
+                  echo "🔢 Total modules to publish: $(echo $json_modules | jq length)"
 
-      - name: 🐹 Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
+            - name: 🐹 Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
 
-      - name: 🚀 Publish modules
-        env:
-          MODULES: ${{ steps.identify-modules.outputs.modules_to_publish }}
-        run: |
-          echo "$MODULES" | jq -r '.[]' | while read -r module_info; do
-            module_name=$(echo "$module_info" | cut -d':' -f1)
-            version=$(echo "$module_info" | cut -d':' -f2)
+            - name: 🚀 Publish modules
+              env:
+                  MODULES: ${{ steps.identify-modules.outputs.modules_to_publish }}
+              run: |
+                  echo "$MODULES" | jq -r '.[]' | while read -r module_info; do
+                    module_name=$(echo "$module_info" | cut -d':' -f1)
+                    version=$(echo "$module_info" | cut -d':' -f2)
 
-            echo "📢 Publishing module: $module_name with version $version"
+                    echo "📢 Publishing module: $module_name with version $version"
 
-            git checkout "refs/tags/${module_name}/${version}"
-            if dagger publish -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version}; then
-              echo "✅ Successfully published $module_name version $version"
-            else
-              echo "::error::❌ Failed to publish $module_name version $version"
-              exit 1
-            fi
-          done
+                    git checkout "refs/tags/${module_name}/${version}"
+                    if dagger publish -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version}; then
+                      echo "✅ Successfully published $module_name version $version"
+                    else
+                      echo "::error::❌ Failed to publish $module_name version $version"
+                      exit 1
+                    fi
+                  done
 
-      - name: 🎉 Publish success notification
-        if: success()
-        run: |
-          echo "::notice::🎊 Successfully published all modules! Great job!"
+            - name: 🎉 Publish success notification
+              if: success()
+              run: |
+                  echo "::notice::🎊 Successfully published all modules! Great job!"
 
-      - name: ❌ Notify on failure
-        if: failure()
-        run: |
-          echo "::error::💥 Failed to publish one or more modules. Please check the logs for details."
+            - name: ❌ Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::💥 Failed to publish one or more modules. Please check the logs for details."

--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -2,93 +2,104 @@
 name: 🎯 Publish Specific Dagger Module Version
 
 on:
-  workflow_dispatch:
-    inputs:
-      module:
-        description: 'Module to publish'
-        required: true
-      version:
-        description: 'Version to publish (e.g., v1.2.3)'
-        required: true
+    workflow_dispatch:
+        inputs:
+            module:
+                description: Module to publish (e.g., module-template)
+                required: true
+            version:
+                description: Version to publish (e.g., v0.1.0)
+                required: true
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 jobs:
-  publish-specific-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛒 Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    publish-specific-version:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: 🛠️ Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          dagger version
-          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
-            echo "::error::Installed Dagger version does not match DAG_VERSION"
-            exit 1
-          fi
+            - name: 🛠️ Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  echo "🔧 Environment setup complete"
 
-      - name: 🔍 Validate inputs
-        id: validate-inputs
-        run: |
-          module="${{ github.event.inputs.module }}"
-          version="${{ github.event.inputs.version }}"
+            - name: 🐳 Install Dagger CLI
+              run: |
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  dagger version
+                  if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+                    echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
+                    exit 1
+                  fi
+                  echo "✅ Dagger CLI installed successfully"
 
-          if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
-            echo "::error::Invalid module: $module"
-            exit 1
-          fi
+            - name: 🔍 Validate inputs and tag
+              id: validate-inputs
+              run: |
+                  module="${{ github.event.inputs.module }}"
+                  version="${{ github.event.inputs.version }}"
 
-          if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: $version. Expected format: vX.Y.Z"
-            exit 1
-          fi
+                  if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
+                    echo "::error::❌ Invalid module: $module"
+                    exit 1
+                  fi
 
-          echo "module=$module" >> $GITHUB_OUTPUT
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "::notice::Inputs validated. Module: $module, Version: $version"
+                  if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "::error::❌ Invalid version format: $version. Expected format: vX.Y.Z"
+                    exit 1
+                  fi
 
-      - name: 🏷️ Check tag existence
-        id: check-tag
-        run: |
-          module=${{ steps.validate-inputs.outputs.module }}
-          version=${{ steps.validate-inputs.outputs.version }}
-          tag="$module/$version"
+                  tag="${module}/${version}"
+                  if ! git rev-parse "$tag" >/dev/null 2>&1; then
+                    echo "::error::❌ Tag $tag does not exist. Cannot publish non-existent version."
+                    exit 1
+                  fi
 
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "::notice::Tag $tag exists. Proceeding with publication."
-            echo "tag_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Tag $tag does not exist. Cannot publish non-existent version."
-            exit 1
-          fi
+                  echo "module=$module" >> $GITHUB_OUTPUT
+                  echo "version=$version" >> $GITHUB_OUTPUT
+                  echo "tag=$tag" >> $GITHUB_OUTPUT
+                  echo "✅ Inputs validated. Module: $module, Version: $version, Tag: $tag"
 
-      - name: 🚀 Publish to Daggerverse
-        if: steps.check-tag.outputs.tag_exists == 'true'
-        run: |
-          module=${{ steps.validate-inputs.outputs.module }}
-          version=${{ steps.validate-inputs.outputs.version }}
-          tag="$module/$version"
+            - name: 🐹 Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
 
-          echo "Publishing $module version $version to Daggerverse"
-          git checkout "refs/tags/$tag"
-          dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version}
-          git checkout -
-          echo "::notice::Successfully published $module version $version to Daggerverse"
+            - name: 🚀 Publish to Daggerverse
+              run: |
+                  module=${{ steps.validate-inputs.outputs.module }}
+                  version=${{ steps.validate-inputs.outputs.version }}
+                  tag=${{ steps.validate-inputs.outputs.tag }}
 
-      - name: 🎉 Notify on completion
-        run: |
-          echo "::notice::Module publication process completed. Check logs for details."
+                  echo "📢 Publishing module: $module with version $version"
 
-      - name: ❌ Notify on failure
-        if: failure()
-        run: |
-          echo "::error::Failed to publish the module. Please check the logs for details."
+                  git checkout "refs/tags/$tag"
+                  if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
+                    echo "✅ Successfully published $module version $version to Daggerverse"
+                    echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+                  else
+                    echo "::error::❌ Failed to publish $module version $version"
+                    exit 1
+                  fi
+                  git checkout -
+
+            - name: 🎉 Publish success notification
+              if: success()
+              run: |
+                  module=${{ steps.validate-inputs.outputs.module }}
+                  version=${{ steps.validate-inputs.outputs.version }}
+                  echo "::notice::🎊 Successfully published ${module}@${version}!"
+                  echo "::notice::🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+
+            - name: ❌ Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::💥 Failed to publish the module. Please check the logs for details."


### PR DESCRIPTION
This commit updates the CD workflow for manual Dagger module publishing:

- Adds workflow_dispatch trigger to allow manual execution
- Accepts inputs for the module to publish and the version bump type
- Identifies all Dagger modules in the repository
- Validates and sets the target modules based on the user input
- Ensures the environment is set up with the required dependencies