### PR TITLE
feat: Improve CD workflow by verifying and checking out tag before publishing

### DIFF
--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -73,15 +73,28 @@ jobs:
               with:
                   go-version: ${{ env.GO_VERSION }}
 
-            - name: 🚀 Publish to Daggerverse
+            - name: 🏷️ Verify and checkout tag
               run: |
                   module=${{ steps.validate-inputs.outputs.module }}
                   version=${{ steps.validate-inputs.outputs.version }}
                   tag=${{ steps.validate-inputs.outputs.tag }}
 
+                  git fetch --all --tags
+                  if git rev-parse "$tag" >/dev/null 2>&1; then
+                    git checkout "refs/tags/$tag"
+                    echo "✅ Successfully checked out tag: $tag"
+                  else
+                    echo "::error::❌ Failed to checkout tag: $tag"
+                    exit 1
+                  fi
+
+            - name: 🚀 Publish to Daggerverse
+              run: |
+                  module=${{ steps.validate-inputs.outputs.module }}
+                  version=${{ steps.validate-inputs.outputs.version }}
+
                   echo "📢 Publishing module: $module with version $version"
 
-                  git checkout "refs/tags/$tag"
                   if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
                     echo "✅ Successfully published $module version $version to Daggerverse"
                     echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
@@ -89,7 +102,6 @@ jobs:
                     echo "::error::❌ Failed to publish $module version $version"
                     exit 1
                   fi
-                  git checkout -
 
             - name: 🎉 Publish success notification
               if: success()


### PR DESCRIPTION
The changes in this commit focus on improving the CD (Continuous Deployment) workflow for publishing specific versions of a module to the Daggerverse. The key changes are:

1. Added a new step to fetch all tags and verify that the specified tag exists before checking it out. This ensures that the workflow only publishes the correct version of the module.
2. Moved the `git checkout` step for the tag to before the `Publish to Daggerverse` step, ensuring that the published version matches the checked-out tag.
3. Removed the unnecessary `git checkout -` command at the end of the workflow.

These changes help to ensure the reliability and consistency of the publishing process, reducing the likelihood of errors or mismatches between the published version and the tagged version in the repository.