### PR TITLE
feat: Update GitHub Actions workflows to include permissions

### DIFF
--- a/.github/workflows/cd-bump-publish-dag-manual.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual.yml
@@ -19,6 +19,10 @@ on:
                     - minor
                     - major
 
+permissions:
+    contents: write
+    pull-requests: write
+
 env:
     GO_VERSION: ~1.22
     DAG_VERSION: 0.12.4

--- a/.github/workflows/cd-publish-dag-modules.yml
+++ b/.github/workflows/cd-publish-dag-modules.yml
@@ -11,6 +11,11 @@ env:
     GO_VERSION: ~1.22
     DAG_VERSION: 0.12.4
 
+permissions:
+    contents: write
+    pull-requests: write
+
+
 jobs:
     detect-and-publish-modules:
         runs-on: ubuntu-latest

--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -15,6 +15,10 @@ env:
     GO_VERSION: ~1.22
     DAG_VERSION: 0.12.4
 
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
     publish-specific-version:
         runs-on: ubuntu-latest
@@ -95,7 +99,9 @@ jobs:
 
                   echo "📢 Publishing module: $module with version $version"
 
-                  if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version#v}; then
+                  git checkout "refs/tags/${module}/${version}"
+
+                  if dagger publish -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
                     echo "✅ Successfully published $module version $version to Daggerverse"
                     echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
                   else


### PR DESCRIPTION
The changes in this commit focus on updating the GitHub Actions workflows to include the necessary permissions for the actions to execute successfully.

The key changes are:

- Add `permissions: contents: write, pull-requests: write` to the workflow files to grant the necessary permissions for the actions.
- Update the `dagger publish` command in the `cd-publish-specific-version.yml` workflow to use the full version tag instead of removing the `v` prefix.

These changes will ensure the GitHub Actions workflows can properly publish the Daggerverse modules to the registry.