### PR TITLE
feat: Improve CD workflow for Dagger module publishing

### DIFF
--- a/.github/workflows/cd-bump-publish-dag-manual.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual.yml
@@ -1,5 +1,5 @@
 ---
-name: 🚀 CD Bump and Publish Dagger Modules
+name: 🚀 CD Bump and Publish Dagger Module(s)
 
 on:
     workflow_dispatch:

--- a/.github/workflows/cd-publish-dag-modules.yml
+++ b/.github/workflows/cd-publish-dag-modules.yml
@@ -1,5 +1,5 @@
 ---
-name: 🚀 CD Publish Dagger Modules
+name: 🚀 CD Publish Dagger Module(s) latest versions
 
 on:
     workflow_dispatch:
@@ -15,7 +15,6 @@ permissions:
     contents: write
     pull-requests: write
 
-
 jobs:
     detect-and-publish-modules:
         runs-on: ubuntu-latest
@@ -29,18 +28,20 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install jq
-                  echo "🔧 Environment setup complete"
-
-            - name: 🐳 Install Dagger CLI
-              run: |
                   curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
                   sudo mv bin/dagger /usr/local/bin/
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  echo "🔧 Environment setup complete"
+
+            - name: 🐳 Verify Dagger CLI
+              run: |
                   dagger version
                   if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
                     echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
                     exit 1
                   fi
-                  echo "✅ Dagger CLI installed successfully"
+                  echo "✅ Dagger CLI verified successfully"
 
             - name: 🔍 Identify modules to publish
               id: identify-modules
@@ -92,13 +93,26 @@ jobs:
 
                     echo "📢 Publishing module: $module_name with version $version"
 
+                    git fetch --all --tags --force
                     git checkout "refs/tags/${module_name}/${version}"
-                    if dagger publish -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version}; then
+
+                    # Clean untracked files
+                    git clean -fd
+
+                    # Stash any changes
+                    git stash --include-untracked
+
+                    if dagger publish --force -m $module_name github.com/Excoriate/daggerverse/${module_name}@${version#v}; then
                       echo "✅ Successfully published $module_name version $version"
                     else
                       echo "::error::❌ Failed to publish $module_name version $version"
                       exit 1
                     fi
+
+                    # Pop stashed changes if any
+                    git stash pop || true
+
+                    git checkout -
                   done
 
             - name: 🎉 Publish success notification

--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -16,7 +16,7 @@ env:
     DAG_VERSION: 0.12.4
 
 permissions:
-    contents: read
+    contents: write
     id-token: write
 
 jobs:
@@ -32,18 +32,20 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install jq
-                  echo "🔧 Environment setup complete"
-
-            - name: 🐳 Install Dagger CLI
-              run: |
                   curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
                   sudo mv bin/dagger /usr/local/bin/
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  echo "🔧 Environment setup complete"
+
+            - name: 🐳 Verify Dagger CLI
+              run: |
                   dagger version
                   if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
                     echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
                     exit 1
                   fi
-                  echo "✅ Dagger CLI installed successfully"
+                  echo "✅ Dagger CLI verified successfully"
 
             - name: 🔍 Validate inputs and tag
               id: validate-inputs
@@ -74,6 +76,8 @@ jobs:
                   go-version: ${{ env.GO_VERSION }}
 
             - name: 🚀 Publish to Daggerverse
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   module="${{ steps.validate-inputs.outputs.module }}"
                   version="${{ steps.validate-inputs.outputs.version }}"
@@ -96,19 +100,14 @@ jobs:
                   # Checkout the specific tag
                   git checkout "refs/tags/$tag"
 
-                  # Get the current commit hash
-                  current_commit=$(git rev-parse HEAD)
-                  tag_commit=$(git rev-parse refs/tags/$tag)
+                  # Clean untracked files
+                  git clean -fd
 
-                  echo "Current commit: $current_commit"
-                  echo "Tag commit: $tag_commit"
+                  # Stash any changes
+                  git stash --include-untracked
 
-                  if [ "$current_commit" != "$tag_commit" ]; then
-                    echo "::warning::⚠️ Current commit does not match the tag commit. This might be okay if the tag was moved."
-                  fi
-
-                  # Use the tag directly in the publish command
-                  if dagger publish -m "$module" "github.com/Excoriate/daggerverse/${module}@${version}"; then
+                  # Use the tag directly in the publish command with --force
+                  if dagger publish --force -m "$module" "github.com/Excoriate/daggerverse/${module}@${version#v}"; then
                     echo "✅ Successfully published $module version $version to Daggerverse"
                     echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
                   else
@@ -116,15 +115,4 @@ jobs:
                     exit 1
                   fi
 
-            - name: 🎉 Publish success notification
-              if: success()
-              run: |
-                  module="${{ steps.validate-inputs.outputs.module }}"
-                  version="${{ steps.validate-inputs.outputs.version }}"
-                  echo "::notice::🎊 Successfully published ${module}@${version}!"
-                  echo "::notice::🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
-
-            - name: ❌ Notify on failure
-              if: failure()
-              run: |
-                  echo "::error::💥 Failed to publish the module. Please check the logs for details."
+                  # Pop stashed changes if any


### PR DESCRIPTION
feat: Improve CD workflow for Dagger module publishing
- Rename CD workflow for Dagger module publishing to be more descriptive
- Update Dagger CLI installation and verification steps
- Grant write permissions to the Git repo for the CI workflow
- Add GH_TOKEN env var to the Dagger module publishing step
- Clean up untracked files before publishing a module
- Remove success/failure notification steps as they are not necessary