### PR TITLE
feat: Implement CD workflow for bumping and publishing Dagger modules

### DIFF
--- a/.github/workflows/cd-bump-dag-module-version.yml
+++ b/.github/workflows/cd-bump-dag-module-version.yml
@@ -1,5 +1,5 @@
 ---
-name: 🏷️ CD Bump Dagger Module Versions
+name: 🏷️ CD Bump Dagger Module Versions on Change
 
 on:
     workflow_dispatch:

--- a/.github/workflows/cd-bump-publish-dag-manual-custom.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual-custom.yml
@@ -2,153 +2,153 @@
 name: 🚀 Bump Custom Version and Publish Dagger Module
 
 on:
-  workflow_dispatch:
-    inputs:
-      module:
-        description: 'Module to bump and publish (e.g., module-template)'
-        required: true
-      bump:
-        description: 'Semver bump type (patch, minor, major)'
-        required: true
-        default: 'minor'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-      version:
-        description: 'Specific version to set (e.g., v1.2.3, overrides bump if provided)'
-        required: false
+    workflow_dispatch:
+        inputs:
+            module:
+                description: Module to bump and publish (e.g., module-template)
+                required: true
+            bump:
+                description: Semver bump type (patch, minor, major)
+                required: true
+                default: minor
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+            version:
+                description: Specific version to set (e.g., v1.2.3, overrides bump if provided)
+                required: false
 
 env:
-  GO_VERSION: ~1.22
-  DAG_VERSION: 0.12.4
+    GO_VERSION: ~1.22
+    DAG_VERSION: 0.12.4
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  bump-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    bump-and-publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📥 Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: 🛠️ Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
-          sudo cp semver-tool-master/src/semver /usr/local/bin/
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
-          sudo mv bin/dagger /usr/local/bin/
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          echo "🔧 Environment setup complete"
+            - name: 🛠️ Set up environment
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install jq
+                  curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+                  sudo cp semver-tool-master/src/semver /usr/local/bin/
+                  curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+                  sudo mv bin/dagger /usr/local/bin/
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  echo "🔧 Environment setup complete"
 
-      - name: 🐳 Verify Dagger CLI
-        run: |
-          dagger version
-          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
-            echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
-            exit 1
-          fi
-          echo "✅ Dagger CLI verified successfully"
+            - name: 🐳 Verify Dagger CLI
+              run: |
+                  dagger version
+                  if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+                    echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
+                    exit 1
+                  fi
+                  echo "✅ Dagger CLI verified successfully"
 
-      - name: 🔍 Validate module
-        id: validate-module
-        run: |
-          module="${{ github.event.inputs.module }}"
-          if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
-            echo "::error::❌ Invalid module: $module. Module directory not found or missing dagger.json"
-            exit 1
-          fi
-          echo "module=$module" >> $GITHUB_OUTPUT
-          echo "✅ Module $module validated successfully"
+            - name: 🔍 Validate module
+              id: validate-module
+              run: |
+                  module="${{ github.event.inputs.module }}"
+                  if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
+                    echo "::error::❌ Invalid module: $module. Module directory not found or missing dagger.json"
+                    exit 1
+                  fi
+                  echo "module=$module" >> $GITHUB_OUTPUT
+                  echo "✅ Module $module validated successfully"
 
-      - name: 📋 List existing tags
-        run: |
-          echo "📑 Existing tags for ${{ steps.validate-module.outputs.module }}:"
-          git tag -l "${{ steps.validate-module.outputs.module }}/*" | sort -V
+            - name: 📋 List existing tags
+              run: |
+                  echo "📑 Existing tags for ${{ steps.validate-module.outputs.module }}:"
+                  git tag -l "${{ steps.validate-module.outputs.module }}/*" | sort -V
 
-      - name: 🏷️ Bump Version and Create Tag
-        id: bump-version
-        run: |
-          module="${{ steps.validate-module.outputs.module }}"
-          latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
-          current_version=$(echo $latest_tag | sed "s|${module}/v||")
-          
-          if [[ -n "${{ github.event.inputs.version }}" ]]; then
-            new_version="${{ github.event.inputs.version }}"
-            if [[ ! $new_version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::❌ Invalid version format. Expected vX.Y.Z"
-              exit 1
-            fi
-          else
-            new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
-          fi
-          
-          new_tag="${module}/${new_version}"
-          
-          if git rev-parse "$new_tag" >/dev/null 2>&1; then
-            echo "::error::❌ Tag $new_tag already exists"
-            exit 1
-          fi
-          
-          git tag -a "$new_tag" -m "Bump $module to $new_version"
-          git push origin "$new_tag"
-          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
-          echo "new_version=${new_version#v}" >> $GITHUB_OUTPUT
-          echo "🎉 New version bumped to $new_version and tagged as $new_tag for $module"
+            - name: 🏷️ Bump Version and Create Tag
+              id: bump-version
+              run: |
+                  module="${{ steps.validate-module.outputs.module }}"
+                  latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
+                  current_version=$(echo $latest_tag | sed "s|${module}/v||")
 
-      - name: 🐹 Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
+                  if [[ -n "${{ github.event.inputs.version }}" ]]; then
+                    new_version="${{ github.event.inputs.version }}"
+                    if [[ ! $new_version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "::error::❌ Invalid version format. Expected vX.Y.Z"
+                      exit 1
+                    fi
+                  else
+                    new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
+                  fi
 
-      - name: 🚀 Publish to Daggerverse
-        run: |
-          module="${{ steps.validate-module.outputs.module }}"
-          version="${{ steps.bump-version.outputs.new_version }}"
-          tag="${{ steps.bump-version.outputs.new_tag }}"
+                  new_tag="${module}/${new_version}"
 
-          echo "📢 Publishing module: $module with version $version"
-          echo "🏷️ Using tag: $tag"
+                  if git rev-parse "$new_tag" >/dev/null 2>&1; then
+                    echo "::error::❌ Tag $new_tag already exists"
+                    exit 1
+                  fi
 
-          git fetch --all --tags --force
-          git checkout "refs/tags/$tag"
+                  git tag -a "$new_tag" -m "Bump $module to $new_version"
+                  git push origin "$new_tag"
+                  echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+                  echo "new_version=${new_version#v}" >> $GITHUB_OUTPUT
+                  echo "🎉 New version bumped to $new_version and tagged as $new_tag for $module"
 
-          # Clean untracked files
-          git clean -fd
+            - name: 🐹 Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: ${{ env.GO_VERSION }}
 
-          # Stash any changes
-          git stash --include-untracked
+            - name: 🚀 Publish to Daggerverse
+              run: |
+                  module="${{ steps.validate-module.outputs.module }}"
+                  version="${{ steps.bump-version.outputs.new_version }}"
+                  tag="${{ steps.bump-version.outputs.new_tag }}"
 
-          if dagger publish --force -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
-            echo "✅ Successfully published $module version $version to Daggerverse"
-            echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
-          else
-            echo "::error::❌ Failed to publish $module version $version"
-            exit 1
-          fi
+                  echo "📢 Publishing module: $module with version $version"
+                  echo "🏷️ Using tag: $tag"
 
-          # Pop stashed changes if any
-          git stash pop || true
+                  git fetch --all --tags --force
+                  git checkout "refs/tags/$tag"
 
-          git checkout -
+                  # Clean untracked files
+                  git clean -fd
 
-      - name: 🎉 Publish success notification
-        if: success()
-        run: |
-          module="${{ steps.validate-module.outputs.module }}"
-          version="${{ steps.bump-version.outputs.new_version }}"
-          echo "::notice::🎊 Successfully bumped version and published ${module}@${version}!"
-          echo "::notice::🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+                  # Stash any changes
+                  git stash --include-untracked
 
-      - name: ❌ Notify on failure
-        if: failure()
-        run: |
-          echo "::error::💥 Failed to bump version or publish the module. Please check the logs for details."
+                  if dagger publish --force -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
+                    echo "✅ Successfully published $module version $version to Daggerverse"
+                    echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+                  else
+                    echo "::error::❌ Failed to publish $module version $version"
+                    exit 1
+                  fi
+
+                  # Pop stashed changes if any
+                  git stash pop || true
+
+                  git checkout -
+
+            - name: 🎉 Publish success notification
+              if: success()
+              run: |
+                  module="${{ steps.validate-module.outputs.module }}"
+                  version="${{ steps.bump-version.outputs.new_version }}"
+                  echo "::notice::🎊 Successfully bumped version and published ${module}@${version}!"
+                  echo "::notice::🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+
+            - name: ❌ Notify on failure
+              if: failure()
+              run: |
+                  echo "::error::💥 Failed to bump version or publish the module. Please check the logs for details."

--- a/.github/workflows/cd-bump-publish-dag-manual-custom.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual-custom.yml
@@ -1,0 +1,154 @@
+---
+name: 🚀 Bump Custom Version and Publish Dagger Module
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to bump and publish (e.g., module-template)'
+        required: true
+      bump:
+        description: 'Semver bump type (patch, minor, major)'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: 'Specific version to set (e.g., v1.2.3, overrides bump if provided)'
+        required: false
+
+env:
+  GO_VERSION: ~1.22
+  DAG_VERSION: 0.12.4
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🛠️ Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+          curl -L https://github.com/fsaintjacques/semver-tool/archive/master.tar.gz | tar xz
+          sudo cp semver-tool-master/src/semver /usr/local/bin/
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAG_VERSION }} sh
+          sudo mv bin/dagger /usr/local/bin/
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          echo "🔧 Environment setup complete"
+
+      - name: 🐳 Verify Dagger CLI
+        run: |
+          dagger version
+          if [[ $(dagger version | grep -oP '(?<=dagger v)\S+') != "${{ env.DAG_VERSION }}" ]]; then
+            echo "::error::❌ Installed Dagger version does not match DAG_VERSION"
+            exit 1
+          fi
+          echo "✅ Dagger CLI verified successfully"
+
+      - name: 🔍 Validate module
+        id: validate-module
+        run: |
+          module="${{ github.event.inputs.module }}"
+          if [[ ! -d "$module" || ! -f "$module/dagger.json" ]]; then
+            echo "::error::❌ Invalid module: $module. Module directory not found or missing dagger.json"
+            exit 1
+          fi
+          echo "module=$module" >> $GITHUB_OUTPUT
+          echo "✅ Module $module validated successfully"
+
+      - name: 📋 List existing tags
+        run: |
+          echo "📑 Existing tags for ${{ steps.validate-module.outputs.module }}:"
+          git tag -l "${{ steps.validate-module.outputs.module }}/*" | sort -V
+
+      - name: 🏷️ Bump Version and Create Tag
+        id: bump-version
+        run: |
+          module="${{ steps.validate-module.outputs.module }}"
+          latest_tag=$(git describe --tags --abbrev=0 --match "${module}/*" 2>/dev/null || echo "${module}/v0.0.0")
+          current_version=$(echo $latest_tag | sed "s|${module}/v||")
+          
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            new_version="${{ github.event.inputs.version }}"
+            if [[ ! $new_version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::❌ Invalid version format. Expected vX.Y.Z"
+              exit 1
+            fi
+          else
+            new_version="v$(semver bump ${{ github.event.inputs.bump }} "v$current_version")"
+          fi
+          
+          new_tag="${module}/${new_version}"
+          
+          if git rev-parse "$new_tag" >/dev/null 2>&1; then
+            echo "::error::❌ Tag $new_tag already exists"
+            exit 1
+          fi
+          
+          git tag -a "$new_tag" -m "Bump $module to $new_version"
+          git push origin "$new_tag"
+          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+          echo "new_version=${new_version#v}" >> $GITHUB_OUTPUT
+          echo "🎉 New version bumped to $new_version and tagged as $new_tag for $module"
+
+      - name: 🐹 Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: 🚀 Publish to Daggerverse
+        run: |
+          module="${{ steps.validate-module.outputs.module }}"
+          version="${{ steps.bump-version.outputs.new_version }}"
+          tag="${{ steps.bump-version.outputs.new_tag }}"
+
+          echo "📢 Publishing module: $module with version $version"
+          echo "🏷️ Using tag: $tag"
+
+          git fetch --all --tags --force
+          git checkout "refs/tags/$tag"
+
+          # Clean untracked files
+          git clean -fd
+
+          # Stash any changes
+          git stash --include-untracked
+
+          if dagger publish --force -m $module github.com/Excoriate/daggerverse/${module}@${version}; then
+            echo "✅ Successfully published $module version $version to Daggerverse"
+            echo "🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+          else
+            echo "::error::❌ Failed to publish $module version $version"
+            exit 1
+          fi
+
+          # Pop stashed changes if any
+          git stash pop || true
+
+          git checkout -
+
+      - name: 🎉 Publish success notification
+        if: success()
+        run: |
+          module="${{ steps.validate-module.outputs.module }}"
+          version="${{ steps.bump-version.outputs.new_version }}"
+          echo "::notice::🎊 Successfully bumped version and published ${module}@${version}!"
+          echo "::notice::🔗 Install with: dagger install github.com/Excoriate/daggerverse/${module}@${version}"
+
+      - name: ❌ Notify on failure
+        if: failure()
+        run: |
+          echo "::error::💥 Failed to bump version or publish the module. Please check the logs for details."


### PR DESCRIPTION
- Add a new workflow `cd-bump-publish-dag-manual-custom.yml` to allow manual bumping and publishing of Dagger modules
- Update the `cd-bump-dag-module-version.yml` workflow name to better reflect its purpose
- The new workflow supports:
  - Manually triggering the workflow to bump and publish a specific module
  - Allowing the user to specify the bump type (patch, minor, major) or a specific version to set
  - Validating the module and its version
  - Automatically creating a new tag for the bumped version
  - Publishing the module to the Daggerverse