### PR TITLE
feat: Extract filename from URL in ModuleTemplate

### DIFF
--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -256,7 +256,6 @@ func (m *ModuleTemplate) WithDownloadedFile(
 	// +optional
 	destFileName string,
 ) *ModuleTemplate {
-	// Extract the filename from the last part of the URL.
 	fileName := filepath.Base(url)
 	if destFileName != "" {
 		fileName = destFileName


### PR DESCRIPTION
Extracts the filename from the last part of the URL in the `WithDownloadedFile` method of the `ModuleTemplate` struct. This change simplifies the code and removes an unnecessary comment.