### PR TITLE
feat: Bump version and publish Dagger module

### DIFF
--- a/.github/workflows/cd-bump-custom-publish-dag-manual-custom.yml
+++ b/.github/workflows/cd-bump-custom-publish-dag-manual-custom.yml
@@ -121,6 +121,16 @@ jobs:
                   git fetch --all --tags --force
                   git checkout "refs/tags/$tag"
 
+                  # Verify we're on the correct commit
+                  current_commit=$(git rev-parse HEAD)
+                  tag_commit=$(git rev-parse $tag)
+                  if [ "$current_commit" != "$tag_commit" ]; then
+                    echo "::error::❌ Failed to checkout the correct commit for tag: $tag"
+                    echo "Current commit: $current_commit"
+                    echo "Tag commit: $tag_commit"
+                    exit 1
+                  fi
+
                   # Clean untracked files
                   git clean -fd
 


### PR DESCRIPTION
- Add a new GitHub Actions workflow to bump the version and publish a Dagger module
- Support manual version bumping (patch, minor, major) or setting a specific version
- Verify the Dagger CLI and module before bumping the version
- Create a new Git tag for the bumped version and push it to the repository
- Set up the Go environment and use the Dagger CLI to publish the module to the Daggerverse