### PR TITLE
feat: Rename methods to use camelCase convention

### DIFF
--- a/.daggerx/templates/examples/go/main.go.backup.tmpl
+++ b/.daggerx/templates/examples/go/main.go.backup.tmpl
@@ -7,11 +7,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Excoriate/daggerverse/module-template/examples/go/internal/dagger"
-	"github.com/sourcegraph/conc/pool"
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/examples/go/internal/dagger"
 )
 
-// Go is a Dagger module that exemplifies the usage of the ModuleTemplate module.
+// Go is a Dagger module that exemplifies the usage of the {{.module_name}} module.
 //
 // This module is used to create and manage containers.
 type Go struct {
@@ -50,63 +49,11 @@ func (m *Go) getTestDir() *dagger.Directory {
 		Directory("./testdata")
 }
 
-// AllRecipes executes all tests.
+// PassedEnvVars demonstrates how to pass environment variables to the {{.module_name}} module.
 //
-// AllRecipes is a helper method for tests, executing the built-in recipes and other specific functionalities of the ModuleTemplate module.
-func (m *Go) AllRecipes(ctx context.Context) error {
-	polTests := pool.New().WithErrors().WithContext(ctx)
-
-	// Test different ways to configure the base container.
-	polTests.Go(m.BuiltInRecipes)
-	// From this point onwards, we're testing the specific functionality of the ModuleTemplate module.
-
-	if err := polTests.Wait(); err != nil {
-		return fmt.Errorf("there are some failed tests: %w", err)
-	}
-
-	return nil
-}
-
-// BuiltInRecipes demonstrates how to run built-in recipes
-//
-// This method showcases the use of various built-in recipes provided by the ModuleTemplate
-// module, including creating a container, running an arbitrary command, and creating a .netrc
-// file for GitHub authentication.
-//
-// Parameters:
-//   - ctx: The context for controlling the function's timeout and cancellation.
-//
-// Returns:
-//   - An error if any of the internal methods fail, or nil otherwise.
-func (m *Go) BuiltInRecipes(ctx context.Context) error {
-	// Pass environment variables to the ModuleTemplate module using ModuleTemplate_PassedEnvVars
-	if err := m.ModuleTemplate_PassedEnvVars(ctx); err != nil {
-		return fmt.Errorf("failed to pass environment variables: %w", err)
-	}
-
-	// Create a configured container using ModuleTemplate_CreateContainer
-	if _, err := m.ModuleTemplate_CreateContainer(ctx); err != nil {
-		return fmt.Errorf("failed to create container: %w", err)
-	}
-
-	// Run an arbitrary command in the container using ModuleTemplate_RunArbitraryCommand
-	if _, err := m.ModuleTemplate_RunArbitraryCommand(ctx); err != nil {
-		return fmt.Errorf("failed to run arbitrary command: %w", err)
-	}
-
-	// Create a .netrc file for GitHub using ModuleTemplate_CreateNetRcFileForGithub
-	if _, err := m.ModuleTemplate_CreateNetRcFileForGithub(ctx); err != nil {
-		return fmt.Errorf("failed to create netrc file: %w", err)
-	}
-
-	return nil
-}
-
-// ModuleTemplate_PassedEnvVars demonstrates how to pass environment variables to the ModuleTemplate module.
-//
-// This method configures a ModuleTemplate module to use specific environment variables from the host.
-func (m *Go) ModuleTemplate_PassedEnvVars(ctx context.Context) error {
-	targetModule := dag.ModuleTemplate(dagger.ModuleTemplateOpts{
+// This method configures a {{.module_name}} module to use specific environment variables from the host.
+func (m *Go) PassedEnvVars(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}(dagger.{{.module_name}}Opts{
 		EnvVarsFromHost: []string{"SOMETHING=SOMETHING,SOMETHING=SOMETHING"},
 	})
 
@@ -129,11 +76,11 @@ func (m *Go) ModuleTemplate_PassedEnvVars(ctx context.Context) error {
 	return nil
 }
 
-// ModuleTemplate_OpenTerminal demonstrates how to open an interactive terminal session
-// within a ModuleTemplate module container.
+// OpenTerminal demonstrates how to open an interactive terminal session
+// within a {{.module_name}} module container.
 //
 // This function showcases the initialization and configuration of a
-// ModuleTemplate module container using various options like enabling Cgo,
+// {{.module_name}} module container using various options like enabling Cgo,
 // utilizing build cache, and including a GCC compiler.
 //
 // Parameters:
@@ -146,9 +93,9 @@ func (m *Go) ModuleTemplate_PassedEnvVars(ctx context.Context) error {
 //
 //	This function can be used to interactively debug or inspect the
 //	container environment during test execution.
-func (m *Go) ModuleTemplate_OpenTerminal() *dagger.Container {
-	// Configure the ModuleTemplate module container with necessary options
-	targetModule := dag.ModuleTemplate()
+func (m *Go) OpenTerminal() *dagger.Container {
+	// Configure the {{.module_name}} module container with necessary options
+	targetModule := dag.{{.module_name}}()
 
 	// Retrieve and discard standard output
 	_, _ = targetModule.Ctr().
@@ -159,10 +106,10 @@ func (m *Go) ModuleTemplate_OpenTerminal() *dagger.Container {
 		Terminal()
 }
 
-// ModuleTemplate_CreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
+// CreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
 //
 // This method exemplifies the creation of a .netrc file with credentials for accessing GitHub,
-// and demonstrates how to pass this file as a secret to the ModuleTemplate module.
+// and demonstrates how to pass this file as a secret to the {{.module_name}} module.
 //
 // Parameters:
 //   - ctx: The context for controlling the function's timeout and cancellation.
@@ -172,13 +119,13 @@ func (m *Go) ModuleTemplate_OpenTerminal() *dagger.Container {
 //
 // Steps Involved:
 //  1. Define GitHub password as a secret.
-//  2. Configure the ModuleTemplate module to use the .netrc file with the provided credentials.
+//  2. Configure the {{.module_name}} module to use the .netrc file with the provided credentials.
 //  3. Run a command inside the container to verify the .netrc file's contents.
-func (m *Go) ModuleTemplate_CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
 	passwordAsSecret := dag.SetSecret("mysecret", "ohboywhatapassword")
 
 	// Configure it for GitHub
-	targetModule := dag.ModuleTemplate().
+	targetModule := dag.{{.module_name}}().
 		WithNewNetrcFileAsSecretGitHub("supersecretuser", passwordAsSecret)
 
 	// Check if the .netrc file is created correctly
@@ -199,10 +146,10 @@ func (m *Go) ModuleTemplate_CreateNetRcFileForGithub(ctx context.Context) (*dagg
 	return targetModule.Ctr(), nil
 }
 
-// ModuleTemplate_RunArbitraryCommand runs an arbitrary shell command in the test container.
+// RunArbitraryCommand runs an arbitrary shell command in the test container.
 //
 // This function demonstrates how to execute a shell command within the container
-// using the ModuleTemplate module.
+// using the {{.module_name}} module.
 //
 // Parameters:
 //
@@ -211,8 +158,8 @@ func (m *Go) ModuleTemplate_CreateNetRcFileForGithub(ctx context.Context) (*dagg
 // Returns:
 //
 //	A string containing the output of the executed command, or an error if the command fails or if the output is empty.
-func (m *Go) ModuleTemplate_RunArbitraryCommand(ctx context.Context) (string, error) {
-	targetModule := dag.ModuleTemplate().WithSource(m.TestDir)
+func (m *Go) RunArbitraryCommand(ctx context.Context) (string, error) {
+	targetModule := dag.{{.module_name}}().WithSource(m.TestDir)
 
 	// Execute the 'ls -l' command
 	out, err := targetModule.
@@ -231,9 +178,9 @@ func (m *Go) ModuleTemplate_RunArbitraryCommand(ctx context.Context) (string, er
 	return out, nil
 }
 
-// ModuleTemplate_CreateContainer initializes and returns a configured Dagger container.
+// CreateContainer initializes and returns a configured Dagger container.
 //
-// This method exemplifies the setup of a container within the ModuleTemplate module using the source directory.
+// This method exemplifies the setup of a container within the {{.module_name}} module using the source directory.
 //
 // Parameters:
 //   - ctx: The context for controlling the function's timeout and cancellation.
@@ -242,11 +189,11 @@ func (m *Go) ModuleTemplate_RunArbitraryCommand(ctx context.Context) (string, er
 //   - A configured Dagger container if successful, or an error if the process fails.
 //
 // Steps Involved:
-//  1. Configure the ModuleTemplate module with the source directory.
+//  1. Configure the {{.module_name}} module with the source directory.
 //  2. Run a command inside the container to check the OS information.
-func (m *Go) ModuleTemplate_CreateContainer(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) CreateContainer(ctx context.Context) (*dagger.Container, error) {
 	targetModule := dag.
-		ModuleTemplate().
+		{{.module_name}}().
 		BaseAlpine().
 		WithUtilitiesInAlpineContainer(). // Install utilities
 		WithGitInAlpineContainer().       // Install git

--- a/.daggerx/templates/examples/go/main.go.tmpl
+++ b/.daggerx/templates/examples/go/main.go.tmpl
@@ -3,11 +3,13 @@ package main
 
 import (
 	"context"
-	"errors"
+  "dagger.io/dagger/dag"
+  "errors"
 	"fmt"
 	"strings"
 
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/examples/go/internal/dagger"
+	"github.com/sourcegraph/conc/pool"
 )
 
 // Go is a Dagger module that exemplifies the usage of the {{.module_name}} module.
@@ -49,10 +51,62 @@ func (m *Go) getTestDir() *dagger.Directory {
 		Directory("./testdata")
 }
 
-// PassedEnvVars demonstrates how to pass environment variables to the {{.module_name}} module.
+// AllRecipes executes all tests.
+//
+// AllRecipes is a helper method for tests, executing the built-in recipes and other specific functionalities of the {{.module_name}} module.
+func (m *Go) AllRecipes(ctx context.Context) error {
+	polTests := pool.New().WithErrors().WithContext(ctx)
+
+	// Test different ways to configure the base container.
+	polTests.Go(m.BuiltInRecipes)
+	// From this point onwards, we're testing the specific functionality of the {{.module_name}} module.
+
+	if err := polTests.Wait(); err != nil {
+		return fmt.Errorf("there are some failed tests: %w", err)
+	}
+
+	return nil
+}
+
+// BuiltInRecipes demonstrates how to run built-in recipes
+//
+// This method showcases the use of various built-in recipes provided by the {{.module_name}}
+// module, including creating a container, running an arbitrary command, and creating a .netrc
+// file for GitHub authentication.
+//
+// Parameters:
+//   - ctx: The context for controlling the function's timeout and cancellation.
+//
+// Returns:
+//   - An error if any of the internal methods fail, or nil otherwise.
+func (m *Go) BuiltInRecipes(ctx context.Context) error {
+	// Pass environment variables to the {{.module_name}} module using {{.module_name}}_PassedEnvVars
+	if err := m.{{.module_name}}_PassedEnvVars(ctx); err != nil {
+		return fmt.Errorf("failed to pass environment variables: %w", err)
+	}
+
+	// Create a configured container using {{.module_name}}_CreateContainer
+	if _, err := m.{{.module_name}}_CreateContainer(ctx); err != nil {
+		return fmt.Errorf("failed to create container: %w", err)
+	}
+
+	// Run an arbitrary command in the container using {{.module_name}}_RunArbitraryCommand
+	if _, err := m.{{.module_name}}_RunArbitraryCommand(ctx); err != nil {
+		return fmt.Errorf("failed to run arbitrary command: %w", err)
+	}
+
+	// Create a .netrc file for GitHub using {{.module_name}}_CreateNetRcFileForGithub
+	if _, err := m.{{.module_name}}_CreateNetRcFileForGithub(ctx); err != nil {
+		return fmt.Errorf("failed to create netrc file: %w", err)
+	}
+
+	return nil
+}
+
+// {{.module_name}}_PassedEnvVars demonstrates how to pass environment variables to the {{.module_name}} module.
 //
 // This method configures a {{.module_name}} module to use specific environment variables from the host.
-func (m *Go) PassedEnvVars(ctx context.Context) error {
+func (m *Go) {{.module_name}}_PassedEnvVars(ctx context.Context) error {
 	targetModule := dag.{{.module_name}}(dagger.{{.module_name}}Opts{
 		EnvVarsFromHost: []string{"SOMETHING=SOMETHING,SOMETHING=SOMETHING"},
 	})
@@ -76,7 +130,7 @@ func (m *Go) PassedEnvVars(ctx context.Context) error {
 	return nil
 }
 
-// OpenTerminal demonstrates how to open an interactive terminal session
+// {{.module_name}}_OpenTerminal demonstrates how to open an interactive terminal session
 // within a {{.module_name}} module container.
 //
 // This function showcases the initialization and configuration of a
@@ -93,7 +147,7 @@ func (m *Go) PassedEnvVars(ctx context.Context) error {
 //
 //	This function can be used to interactively debug or inspect the
 //	container environment during test execution.
-func (m *Go) OpenTerminal() *dagger.Container {
+func (m *Go) {{.module_name}}_OpenTerminal() *dagger.Container {
 	// Configure the {{.module_name}} module container with necessary options
 	targetModule := dag.{{.module_name}}()
 
@@ -106,7 +160,7 @@ func (m *Go) OpenTerminal() *dagger.Container {
 		Terminal()
 }
 
-// CreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
+// {{.module_name}}_CreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
 //
 // This method exemplifies the creation of a .netrc file with credentials for accessing GitHub,
 // and demonstrates how to pass this file as a secret to the {{.module_name}} module.
@@ -121,7 +175,7 @@ func (m *Go) OpenTerminal() *dagger.Container {
 //  1. Define GitHub password as a secret.
 //  2. Configure the {{.module_name}} module to use the .netrc file with the provided credentials.
 //  3. Run a command inside the container to verify the .netrc file's contents.
-func (m *Go) CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) {{.module_name}}_CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
 	passwordAsSecret := dag.SetSecret("mysecret", "ohboywhatapassword")
 
 	// Configure it for GitHub
@@ -146,7 +200,7 @@ func (m *Go) CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, e
 	return targetModule.Ctr(), nil
 }
 
-// RunArbitraryCommand runs an arbitrary shell command in the test container.
+// {{.module_name}}_RunArbitraryCommand runs an arbitrary shell command in the test container.
 //
 // This function demonstrates how to execute a shell command within the container
 // using the {{.module_name}} module.
@@ -158,7 +212,7 @@ func (m *Go) CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, e
 // Returns:
 //
 //	A string containing the output of the executed command, or an error if the command fails or if the output is empty.
-func (m *Go) RunArbitraryCommand(ctx context.Context) (string, error) {
+func (m *Go) {{.module_name}}_RunArbitraryCommand(ctx context.Context) (string, error) {
 	targetModule := dag.{{.module_name}}().WithSource(m.TestDir)
 
 	// Execute the 'ls -l' command
@@ -178,7 +232,7 @@ func (m *Go) RunArbitraryCommand(ctx context.Context) (string, error) {
 	return out, nil
 }
 
-// CreateContainer initializes and returns a configured Dagger container.
+// {{.module_name}}_CreateContainer initializes and returns a configured Dagger container.
 //
 // This method exemplifies the setup of a container within the {{.module_name}} module using the source directory.
 //
@@ -191,7 +245,7 @@ func (m *Go) RunArbitraryCommand(ctx context.Context) (string, error) {
 // Steps Involved:
 //  1. Configure the {{.module_name}} module with the source directory.
 //  2. Run a command inside the container to check the OS information.
-func (m *Go) CreateContainer(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) {{.module_name}}_CreateContainer(ctx context.Context) (*dagger.Container, error) {
 	targetModule := dag.
 		{{.module_name}}().
 		BaseAlpine().

--- a/.daggerx/templates/examples/go/main.go.tmpl
+++ b/.daggerx/templates/examples/go/main.go.tmpl
@@ -53,7 +53,8 @@ func (m *Go) getTestDir() *dagger.Directory {
 
 // AllRecipes executes all tests.
 //
-// AllRecipes is a helper method for tests, executing the built-in recipes and other specific functionalities of the {{.module_name}} module.
+// AllRecipes is a helper method for tests, executing the built-in recipes and
+// other specific functionalities of the {{.module_name}} module.
 func (m *Go) AllRecipes(ctx context.Context) error {
 	polTests := pool.New().WithErrors().WithContext(ctx)
 

--- a/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
+++ b/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
@@ -219,32 +219,11 @@ jobs:
                   cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Running Recipes create container 💣 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
+            - name: Running Recipes all recipes 💣 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
               uses: dagger/dagger-for-github@v6
               with:
                   verb: call
-                  args: create-container
-                  module: {{.module_name_pkg}}/examples/go
-                  version: ${{ matrix.dagversion }}
-                  cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Running Recipes passed env vars 💣 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
-              uses: dagger/dagger-for-github@v6
-              with:
-                  verb: call
-                  args: passed-env-vars
-                  module: {{.module_name_pkg}}/examples/go
-                  version: ${{ matrix.dagversion }}
-                  cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Running Recipes run-arbitrary-command 💣 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
-              uses: dagger/dagger-for-github@v6
-              with:
-                  verb: call
-                  args: run-arbitrary-command
+                  args: all-recipes
                   module: {{.module_name_pkg}}/examples/go
                   version: ${{ matrix.dagversion }}
                   cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/ci-module-template.yaml
+++ b/.github/workflows/ci-module-template.yaml
@@ -219,32 +219,11 @@ jobs:
                   cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Running Recipes create container 💣 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
+            - name: Running Recipes all recipes 💣 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
               uses: dagger/dagger-for-github@v6
               with:
                   verb: call
-                  args: create-container
-                  module: module-template/examples/go
-                  version: ${{ matrix.dagversion }}
-                  cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Running Recipes passed env vars 💣 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
-              uses: dagger/dagger-for-github@v6
-              with:
-                  verb: call
-                  args: passed-env-vars
-                  module: module-template/examples/go
-                  version: ${{ matrix.dagversion }}
-                  cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Running Recipes run-arbitrary-command 💣 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
-              uses: dagger/dagger-for-github@v6
-              with:
-                  verb: call
-                  args: run-arbitrary-command
+                  args: all-recipes
                   module: module-template/examples/go
                   version: ${{ matrix.dagversion }}
                   cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,6 +131,15 @@ issues:
         - linters:
               - lll
           source: '^//go:generate '
+        - linters:
+              - revive
+          text: don't use underscores in Go names
+          path: main\.go$
+        - linters:
+              - stylecheck
+          text: 'ST1003: should not use underscores in Go names'
+          path: main\.go$
+
     exclude-use-default: false
     exclude-case-sensitive: false
     exclude-dirs:

--- a/justfile
+++ b/justfile
@@ -127,10 +127,7 @@ examplesgo mod: (reloadmod mod)
   @echo "Running Dagger module examples (Go SDK)..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/examples/go || (echo "Module examples not found" && exit 1)
-  @cd {{mod}}/examples/go && dagger call create-container
-  @cd {{mod}}/examples/go && dagger call run-arbitrary-command
-  @cd {{mod}}/examples/go && dagger call passed-env-vars
-  @cd {{mod}}/examples/go && dagger call create-net-rc-file-for-github
+  @cd {{mod}}/examples/go && dagger call all-recipes
 
 # Recipe to run GolangCI Lint
 golint mod:

--- a/module-template/examples/go/go.mod
+++ b/module-template/examples/go/go.mod
@@ -5,6 +5,7 @@ go 1.22.5
 require (
 	github.com/99designs/gqlgen v0.17.49
 	github.com/Khan/genqlient v0.7.0
+	github.com/sourcegraph/conc v0.3.0
 	github.com/vektah/gqlparser/v2 v2.5.16
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
@@ -31,6 +32,8 @@ require (
 	github.com/sosodev/duration v1.3.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/module-template/examples/go/go.sum
+++ b/module-template/examples/go/go.sum
@@ -29,7 +29,10 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq4=
 github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -59,8 +62,12 @@ go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
+go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=

--- a/module-template/examples/go/main.go
+++ b/module-template/examples/go/main.go
@@ -52,7 +52,8 @@ func (m *Go) getTestDir() *dagger.Directory {
 
 // AllRecipes executes all tests.
 //
-// AllRecipes is a helper method for tests, executing the built-in recipes and other specific functionalities of the ModuleTemplate module.
+// AllRecipes is a helper method for tests, executing the built-in recipes and
+// other specific functionalities of the ModuleTemplate module.
 func (m *Go) AllRecipes(ctx context.Context) error {
 	polTests := pool.New().WithErrors().WithContext(ctx)
 

--- a/module-template/examples/go/main.go
+++ b/module-template/examples/go/main.go
@@ -49,10 +49,10 @@ func (m *Go) getTestDir() *dagger.Directory {
 		Directory("./testdata")
 }
 
-// ModuleTemplatePassedEnvVars demonstrates how to pass environment variables to the ModuleTemplate module.
+// ModuleTemplate_PassedEnvVars demonstrates how to pass environment variables to the ModuleTemplate module.
 //
 // This method configures a ModuleTemplate module to use specific environment variables from the host.
-func (m *Go) ModuleTemplatePassedEnvVars(ctx context.Context) error {
+func (m *Go) ModuleTemplate_PassedEnvVars(ctx context.Context) error {
 	targetModule := dag.ModuleTemplate(dagger.ModuleTemplateOpts{
 		EnvVarsFromHost: []string{"SOMETHING=SOMETHING,SOMETHING=SOMETHING"},
 	})
@@ -76,7 +76,7 @@ func (m *Go) ModuleTemplatePassedEnvVars(ctx context.Context) error {
 	return nil
 }
 
-// ModuleTemplateOpenTerminal demonstrates how to open an interactive terminal session
+// ModuleTemplate_OpenTerminal demonstrates how to open an interactive terminal session
 // within a ModuleTemplate module container.
 //
 // This function showcases the initialization and configuration of a
@@ -93,7 +93,7 @@ func (m *Go) ModuleTemplatePassedEnvVars(ctx context.Context) error {
 //
 //	This function can be used to interactively debug or inspect the
 //	container environment during test execution.
-func (m *Go) ModuleTemplateOpenTerminal() *dagger.Container {
+func (m *Go) ModuleTemplate_OpenTerminal() *dagger.Container {
 	// Configure the ModuleTemplate module container with necessary options
 	targetModule := dag.ModuleTemplate()
 
@@ -106,7 +106,7 @@ func (m *Go) ModuleTemplateOpenTerminal() *dagger.Container {
 		Terminal()
 }
 
-// ModuleTemplateCreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
+// ModuleTemplate_CreateNetRcFileForGithub creates and configures a .netrc file for GitHub authentication.
 //
 // This method exemplifies the creation of a .netrc file with credentials for accessing GitHub,
 // and demonstrates how to pass this file as a secret to the ModuleTemplate module.
@@ -121,7 +121,7 @@ func (m *Go) ModuleTemplateOpenTerminal() *dagger.Container {
 //  1. Define GitHub password as a secret.
 //  2. Configure the ModuleTemplate module to use the .netrc file with the provided credentials.
 //  3. Run a command inside the container to verify the .netrc file's contents.
-func (m *Go) ModuleTemplateCreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) ModuleTemplate_CreateNetRcFileForGithub(ctx context.Context) (*dagger.Container, error) {
 	passwordAsSecret := dag.SetSecret("mysecret", "ohboywhatapassword")
 
 	// Configure it for GitHub
@@ -146,7 +146,7 @@ func (m *Go) ModuleTemplateCreateNetRcFileForGithub(ctx context.Context) (*dagge
 	return targetModule.Ctr(), nil
 }
 
-// ModuleTemplateRunArbitraryCommand runs an arbitrary shell command in the test container.
+// ModuleTemplate_RunArbitraryCommand runs an arbitrary shell command in the test container.
 //
 // This function demonstrates how to execute a shell command within the container
 // using the ModuleTemplate module.
@@ -158,7 +158,7 @@ func (m *Go) ModuleTemplateCreateNetRcFileForGithub(ctx context.Context) (*dagge
 // Returns:
 //
 //	A string containing the output of the executed command, or an error if the command fails or if the output is empty.
-func (m *Go) ModuleTemplateRunArbitraryCommand(ctx context.Context) (string, error) {
+func (m *Go) ModuleTemplate_RunArbitraryCommand(ctx context.Context) (string, error) {
 	targetModule := dag.ModuleTemplate().WithSource(m.TestDir)
 
 	// Execute the 'ls -l' command
@@ -178,7 +178,7 @@ func (m *Go) ModuleTemplateRunArbitraryCommand(ctx context.Context) (string, err
 	return out, nil
 }
 
-// ModuleTemplateCreateContainer initializes and returns a configured Dagger container.
+// ModuleTemplate_CreateContainer initializes and returns a configured Dagger container.
 //
 // This method exemplifies the setup of a container within the ModuleTemplate module using the source directory.
 //
@@ -191,7 +191,7 @@ func (m *Go) ModuleTemplateRunArbitraryCommand(ctx context.Context) (string, err
 // Steps Involved:
 //  1. Configure the ModuleTemplate module with the source directory.
 //  2. Run a command inside the container to check the OS information.
-func (m *Go) ModuleTemplateCreateContainer(ctx context.Context) (*dagger.Container, error) {
+func (m *Go) ModuleTemplate_CreateContainer(ctx context.Context) (*dagger.Container, error) {
 	targetModule := dag.
 		ModuleTemplate().
 		BaseAlpine().


### PR DESCRIPTION
Rename the following methods to follow the camelCase naming convention:
- `ModuleTemplateCreateNetRcFileForGithub` -> `ModuleTemplate_CreateNetRcFileForGithub`
- `ModuleTemplateRunArbitraryCommand` -> `ModuleTemplate_RunArbitraryCommand`
- `ModuleTemplateCreateContainer` -> `ModuleTemplate_CreateContainer`
- `ModuleTemplateOpenTerminal` -> `ModuleTemplate_OpenTerminal`
- `ModuleTemplatePassedEnvVars` -> `ModuleTemplate_PassedEnvVars`
This change aligns the method names with the established Go naming conventions.

docs: Update comments to match method name changes
Update the comments for the renamed methods to reflect the new camelCase names.

ci: Add linter rules to enforce camelCase naming
Add linter rules to the .golangci.yml file to enforce the use of camelCase for method names in the main.go file.