### PR TITLE
feat: Add Git and utilities installation for Ubuntu-based containers

### DIFF
--- a/.daggerx/templates/module/apis.go.tmpl
+++ b/.daggerx/templates/module/apis.go.tmpl
@@ -8,7 +8,7 @@ package main
 
 import (
 	"context"
-    "fmt"
+  	"fmt"
 	"path/filepath"
 	"time"
 
@@ -151,6 +151,20 @@ func (m *{{.module_name}}) WithGitInAlpineContainer() *{{.module_name}} {
 	return m
 }
 
+// WithGitInUbuntuContainer installs Git in the Ubuntu-based container.
+//
+// This method installs Git in the Ubuntu-based container.
+//
+// Returns:
+//   - *{{.module_name}}: The updated {{.module_name}} with Git installed in the container.
+func (m *{{.module_name}}) WithGitInUbuntuContainer() *{{.module_name}} {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "update", "-y"}).
+		WithExec([]string{"apt-get", "install", "-y", "git"})
+
+	return m
+}
+
 // WithNewNetrcFileGitHub creates a new .netrc file with the GitHub credentials.
 //
 // The .netrc file is created in the root directory of the container.
@@ -213,6 +227,21 @@ func (m *{{.module_name}}) WithUtilitiesInAlpineContainer() *{{.module_name}} {
 	m.Ctr = m.Ctr.
 		WithExec([]string{"apk", "update"}).
 		WithExec([]string{"apk", "add", "curl", "wget", "bash", "jq", "vim"})
+
+	return m
+}
+
+// WithUtilitiesInUbuntuContainer installs common utilities in the Ubuntu-based container.
+//
+// This method updates the package lists for upgrades and installs the specified utilities
+// such as curl, wget, bash, jq, and vim in the Ubuntu-based container.
+//
+// Returns:
+//   - *{{.module_name}}: The updated {{.module_name}} with the utilities installed in the container.
+func (m *{{.module_name}}) WithUtilitiesInUbuntuContainer() *{{.module_name}} {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "bash", "jq", "vim"})
 
 	return m
 }

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -78,6 +78,9 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithSource)
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
+	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
+	polTests.Go(m.TestWithGitInAlpineContainer)
+	polTests.Go(m.TestWithGitInUbuntuContainer)
 	polTests.Go(m.TestWithNewNetrcFileGitHub)
 	polTests.Go(m.TestWithNewNetrcFileAsSecretGitHub)
 	polTests.Go(m.TestWithNewNetrcFileGitLab)
@@ -489,6 +492,139 @@ func (m *Tests) TestWithUtilitiesInAlpineContainer(ctx context.Context) error {
 		return fmt.Errorf("%w, expected 'curl' to be available in the container, got %s", errExpectedContentNotMatch, out)
 	}
 
+	return nil
+}
+
+// TestWithUtilitiesInUbuntuContainer tests if the Alpine container with utilities is set correctly.
+//
+// This method verifies that the Alpine container includes specific utilities by running a command within the container.
+// The test checks if the 'curl' utility is available and functioning as expected.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+// - error: Returns an error if the utility check fails or the output does not contain the expected results.
+func (m *Tests) TestWithUtilitiesInUbuntuContainer(ctx context.Context) error {
+	// Configure an ubuntu container.
+	ubuntuCtr := dag.Container().
+		From("ubuntu:latest")
+
+	// Initialize the target module with the Alpine container and utilities.
+	targetModule := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: ubuntuCtr,
+		})
+
+	targetModule = targetModule.WithUtilitiesInUbuntuContainer()
+
+	// Execute the 'curl --version' command within the container to verify 'curl' utility.
+	out, err := targetModule.
+		Ctr().
+		WithExec([]string{"curl", "--version"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	if !strings.Contains(out, "curl") {
+		return fmt.Errorf("%w, expected 'curl' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	return nil
+}
+
+// TestWithGitInAlpineContainer tests the presence of the Git version control system
+// within an Alpine-based container.
+//
+// This method configures the target module to include Git within an Alpine container,
+// executes a command to check the Git version, and verifies the output.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue configuring the container,
+//     executing the command, or if the output does not contain the expected Git version information.
+func (m *Tests) TestWithGitInAlpineContainer(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}()
+
+	// Configure the target module to include Git in an Alpine container
+	targetModule = targetModule.WithGitInAlpineContainer()
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	// Check if the command output is empty
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	// Check if the Git version information is present in the output
+	if !strings.Contains(out, "git version") {
+		return fmt.Errorf("%w, expected 'git' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	return nil
+}
+
+// TestWithGitInUbuntuContainer verifies that the 'git' command is available
+// in the target module's container which uses an Ubuntu base image.
+//
+// This method reconfigures the target module to include 'git' in an Ubuntu container,
+// executes the 'git --version' command within the container to confirm its presence,
+// and checks the output to ensure 'git' is correctly installed.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue configuring the container,
+//     executing the 'git' command, or if the 'git' command is not found in the output.
+func (m *Tests) TestWithGitInUbuntuContainer(ctx context.Context) error {
+	// Configure an ubuntu container.
+	ubuntuCtr := dag.Container().
+		From("ubuntu:latest")
+
+	// Initialize the target module.
+	targetModule := dag.{{.module_name}}(dagger.{{.module_name}}Opts{
+		Ctr: ubuntuCtr,
+	})
+
+	// Configure the target module to include 'git' in an Ubuntu container.
+	targetModule = targetModule.WithGitInUbuntuContainer()
+
+	// Execute the 'git --version' command to verify 'git' is installed.
+	out, err := targetModule.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+		// Check for errors executing the command.
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	// Check if the output is empty, which indicates the command may have failed.
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	// Check if the output contains 'git version' to confirm 'git' is available.
+	if !strings.Contains(out, "git version") {
+		return fmt.Errorf("%w, expected 'git' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	// Return nil if 'git' was successfully verified.
 	return nil
 }
 

--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -151,6 +151,19 @@ func (m *ModuleTemplate) WithGitInAlpineContainer() *ModuleTemplate {
 	return m
 }
 
+// WithGitInUbuntuContainer installs Git in the Ubuntu-based container.
+//
+// This method installs Git in the Ubuntu-based container.
+//
+// Returns:
+//   - *ModuleTemplate: The updated ModuleTemplate with Git installed in the container.
+func (m *ModuleTemplate) WithGitInUbuntuContainer() *ModuleTemplate {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "install", "-y", "git"})
+
+	return m
+}
+
 // WithNewNetrcFileGitHub creates a new .netrc file with the GitHub credentials.
 //
 // The .netrc file is created in the root directory of the container.
@@ -213,6 +226,21 @@ func (m *ModuleTemplate) WithUtilitiesInAlpineContainer() *ModuleTemplate {
 	m.Ctr = m.Ctr.
 		WithExec([]string{"apk", "update"}).
 		WithExec([]string{"apk", "add", "curl", "wget", "bash", "jq", "vim"})
+
+	return m
+}
+
+// WithUtilitiesInUbuntuContainer installs common utilities in the Ubuntu-based container.
+//
+// This method updates the package lists for upgrades and installs the specified utilities
+// such as curl, wget, bash, jq, and vim in the Ubuntu-based container.
+//
+// Returns:
+//   - *ModuleTemplate: The updated ModuleTemplate with the utilities installed in the container.
+func (m *ModuleTemplate) WithUtilitiesInUbuntuContainer() *ModuleTemplate {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "bash", "jq", "vim"})
 
 	return m
 }

--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -159,6 +159,7 @@ func (m *ModuleTemplate) WithGitInAlpineContainer() *ModuleTemplate {
 //   - *ModuleTemplate: The updated ModuleTemplate with Git installed in the container.
 func (m *ModuleTemplate) WithGitInUbuntuContainer() *ModuleTemplate {
 	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "update", "-y"}).
 		WithExec([]string{"apt-get", "install", "-y", "git"})
 
 	return m

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -78,6 +78,9 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithSource)
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
+	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
+	polTests.Go(m.TestWithGitInAlpineContainer)
+	polTests.Go(m.TestWithGitInUbuntuContainer)
 	polTests.Go(m.TestWithNewNetrcFileGitHub)
 	polTests.Go(m.TestWithNewNetrcFileAsSecretGitHub)
 	polTests.Go(m.TestWithNewNetrcFileGitLab)
@@ -489,6 +492,139 @@ func (m *Tests) TestWithUtilitiesInAlpineContainer(ctx context.Context) error {
 		return fmt.Errorf("%w, expected 'curl' to be available in the container, got %s", errExpectedContentNotMatch, out)
 	}
 
+	return nil
+}
+
+// TestWithUtilitiesInUbuntuContainer tests if the Alpine container with utilities is set correctly.
+//
+// This method verifies that the Alpine container includes specific utilities by running a command within the container.
+// The test checks if the 'curl' utility is available and functioning as expected.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+// - error: Returns an error if the utility check fails or the output does not contain the expected results.
+func (m *Tests) TestWithUtilitiesInUbuntuContainer(ctx context.Context) error {
+	// Configure an ubuntu container.
+	ubuntuCtr := dag.Container().
+		From("ubuntu:latest")
+
+	// Initialize the target module with the Alpine container and utilities.
+	targetModule := dag.
+		ModuleTemplate(dagger.ModuleTemplateOpts{
+			Ctr: ubuntuCtr,
+		})
+
+	targetModule = targetModule.WithUtilitiesInUbuntuContainer()
+
+	// Execute the 'curl --version' command within the container to verify 'curl' utility.
+	out, err := targetModule.
+		Ctr().
+		WithExec([]string{"curl", "--version"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	if !strings.Contains(out, "curl") {
+		return fmt.Errorf("%w, expected 'curl' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	return nil
+}
+
+// TestWithGitInAlpineContainer tests the presence of the Git version control system
+// within an Alpine-based container.
+//
+// This method configures the target module to include Git within an Alpine container,
+// executes a command to check the Git version, and verifies the output.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue configuring the container,
+//     executing the command, or if the output does not contain the expected Git version information.
+func (m *Tests) TestWithGitInAlpineContainer(ctx context.Context) error {
+	targetModule := dag.ModuleTemplate()
+
+	// Configure the target module to include Git in an Alpine container
+	targetModule = targetModule.WithGitInAlpineContainer()
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	// Check if the command output is empty
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	// Check if the Git version information is present in the output
+	if !strings.Contains(out, "git version") {
+		return fmt.Errorf("%w, expected 'git' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	return nil
+}
+
+// TestWithGitInUbuntuContainer verifies that the 'git' command is available
+// in the target module's container which uses an Ubuntu base image.
+//
+// This method reconfigures the target module to include 'git' in an Ubuntu container,
+// executes the 'git --version' command within the container to confirm its presence,
+// and checks the output to ensure 'git' is correctly installed.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue configuring the container,
+//     executing the 'git' command, or if the 'git' command is not found in the output.
+func (m *Tests) TestWithGitInUbuntuContainer(ctx context.Context) error {
+	// Configure an ubuntu container.
+	ubuntuCtr := dag.Container().
+		From("ubuntu:latest")
+
+	// Initialize the target module.
+	targetModule := dag.ModuleTemplate(dagger.ModuleTemplateOpts{
+		Ctr: ubuntuCtr,
+	})
+
+	// Configure the target module to include 'git' in an Ubuntu container.
+	targetModule = targetModule.WithGitInUbuntuContainer()
+
+	// Execute the 'git --version' command to verify 'git' is installed.
+	out, err := targetModule.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+		// Check for errors executing the command.
+	if err != nil {
+		return fmt.Errorf("%w, failed to run shell command: %w", errUnderlyingDagger, err)
+	}
+
+	// Check if the output is empty, which indicates the command may have failed.
+	if out == "" {
+		return fmt.Errorf("%w, expected to have at least one folder, got empty output", errEmptyOutput)
+	}
+
+	// Check if the output contains 'git version' to confirm 'git' is available.
+	if !strings.Contains(out, "git version") {
+		return fmt.Errorf("%w, expected 'git' to be available in the container, got %s", errExpectedContentNotMatch, out)
+	}
+
+	// Return nil if 'git' was successfully verified.
 	return nil
 }
 


### PR DESCRIPTION
    
This commit introduces two new methods to the `ModuleTemplate` struct:
    
1. `WithGitInUbuntuContainer()`: This method installs Git in the Ubuntu-based container.
2. `WithUtilitiesInUbuntuContainer()`: This method updates the package lists and installs common utilities such as curl, wget, bash, jq, and vim in the Ubuntu-based container.
    
These new methods provide an alternative to the existing `WithGitInAlpineContainer()` and `WithUtilitiesInAlpineContainer()` methods, which are specific to Alpine-based containers. This allows users to choose the appropriate container base image (Alpine or Ubuntu) and install the necessary tools accordingly.