### PR TITLE
feat: Add AWS CLI tests in Alpine and Ubuntu containers

### DIFF
--- a/.daggerx/templates/module/clis.go.tmpl
+++ b/.daggerx/templates/module/clis.go.tmpl
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 // WithAWSCLIInAlpineContainer installs the AWS CLI in the
 // Alpine-based container.
 // This method installs the AWS CLI in a golang/alpine container
@@ -18,17 +20,39 @@ func (m *{{.module_name}}) WithAWSCLIInAlpineContainer() *{{.module_name}} {
 
 // WithAWSCLIInUbuntuContainer installs the AWS CLI in the Ubuntu-based container.
 //
-// This method installs the AWS CLI in an Ubuntu-based
-// container using the 'apt-get' package manager.
-// It is particularly useful for environments that need to
-// interact with AWS services.
+// This method installs the AWS CLI in an Ubuntu-based container following the
+// official AWS installation steps.
+//
+// Args:
+//   - architecture (string): The architecture for which the AWS CLI should be downloaded.
+//     Valid values are "x86_64" and "aarch64". Default is "x86_64".
 //
 // Returns:
 //   - *{{.module_name}}: The updated {{.module_name}} with the AWS CLI installed in the container.
-func (m *{{.module_name}}) WithAWSCLIInUbuntuContainer() *{{.module_name}} {
+func (m *{{.module_name}}) WithAWSCLIInUbuntuContainer(
+	// architecture is the architecture for which the AWS CLI should be downloaded.
+	// Valid values are "x86_64" and "aarch64". Default is "x86_64".
+	// +optional
+	architecture string) *{{.module_name}} {
+	// Validate and default the architecture argument
+	switch architecture {
+	case "":
+		architecture = "x86_64"
+	case "aarch64", "x86_64":
+		// valid architectures
+	default:
+		panic("Invalid architecture specified. Supported values are 'x86_64' and 'aarch64'.")
+	}
+
+	url := fmt.Sprintf("https://awscli.amazonaws.com/awscli-exe-linux-%s.zip", architecture)
+
 	m.Ctr = m.Ctr.
 		WithExec([]string{"apt-get", "update"}).
-		WithExec([]string{"apt-get", "install", "-y", "awscli"})
+		WithExec([]string{"apt-get", "install", "-y", "unzip", "curl", "sudo"}).
+		WithExec([]string{"curl", "-L", url, "-o", "awscliv2.zip"}).
+		WithExec([]string{"unzip", "awscliv2.zip"}).
+		WithExec([]string{"sudo", "./aws/install"}).
+		WithExec([]string{"rm", "-rf", "awscliv2.zip", "aws"})
 
 	return m
 }

--- a/.daggerx/templates/tests/cli.go.tmpl
+++ b/.daggerx/templates/tests/cli.go.tmpl
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+)
+
+// TestWithAWSCLIInAlpineContainer verifies that the AWS CLI is
+// correctly installed
+// inside an Alpine container, both in terms of binary location and version.
+//
+// It performs the following checks:
+// 1. Verifies if the AWS CLI binary is installed in the OS
+// filesystem using the `which aws` command.
+// 2. Confirms the AWS CLI version by executing `aws --version`.
+//
+// If any of these checks fail, the function returns an error detailing the failure.
+func (m *Tests) TestWithAWSCLIInAlpineContainer(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}()
+
+	// Configure the target module to use AWS CLI in Alpine container
+	targetModule = targetModule.WithAwscliinAlpineContainer()
+	// Check if the AWS CLI binary is installed in the OS filesystem
+	out, whichErr := targetModule.
+		Ctr().
+		WithExec([]string{"which", "aws"}).
+		Stdout(ctx)
+
+	if whichErr != nil {
+		return WrapError(whichErr, "failed to get AWS CLI binary path")
+	}
+
+	if !strings.Contains(out, "/usr/bin/aws") {
+		return Errorf("expected AWS CLI binary to be in "+
+			"/usr/bin/aws, got %s", out)
+	}
+
+	// Check if the AWS CLI binary is installed and get its version
+	outVersion, errVersion := targetModule.
+		Ctr().
+		WithExec([]string{"aws", "--version"}).
+		Stdout(ctx)
+
+	if errVersion != nil {
+		return WrapError(errVersion, "failed to get AWS CLI version")
+	}
+
+	if !strings.Contains(outVersion, "aws-cli/2") {
+		return Errorf("expected AWS CLI version to be 2, got %s", outVersion)
+	}
+
+	return nil
+}
+
+// TestWithAWSCLIInUbuntuContainer verifies that the AWS CLI is
+// correctly installed inside an Ubuntu container, both in terms of
+// binary location and version.
+//
+// It performs the following checks:
+// 1. Verifies if the AWS CLI binary is installed in the OS
+// filesystem using the `which aws` command.
+// 2. Confirms the AWS CLI version by executing `aws --version`.
+//
+// If any of these checks fail, the function returns an error detailing the failure.
+func (m *Tests) TestWithAWSCLIInUbuntuContainer(ctx context.Context) error {
+	targetModule := dag.
+		{{.module_name}}().
+		BaseUbuntu()
+
+	// Configure the target module to use AWS CLI in Ubuntu container
+	targetModule = targetModule.
+		WithAwscliinUbuntuContainer(dagger.
+			{{.module_name}}WithAwscliinUbuntuContainerOpts{
+			Architecture: "x86_64",
+		})
+
+	// Check if the AWS CLI binary is installed in the OS filesystem
+	out, whichErr := targetModule.Ctr().
+		WithExec([]string{"which", "aws"}).
+		Stdout(ctx)
+
+	if whichErr != nil {
+		return WrapError(whichErr, "failed to get AWS CLI binary path")
+	}
+
+	if !strings.Contains(out, "/usr/local/bin/aws") {
+		return Errorf("expected AWS CLI binary to "+
+			"be in /usr/local/bin/aws, got %s", out)
+	}
+
+	// List on /usr/local/bin/aws
+	lsOut, lsErr := targetModule.Ctr().
+		WithExec([]string{"ls", "/usr/local/bin/aws"}).
+		Stdout(ctx)
+
+	if lsErr != nil {
+		return WrapError(lsErr, "failed to list /usr/local/bin/aws")
+	}
+
+	if !strings.Contains(lsOut, "aws") {
+		return Errorf("expected AWS CLI binary to be in /usr/local/bin/aws, got %s", lsOut)
+	}
+
+	return nil
+}

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -100,6 +100,10 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)
 
+	// Test CLI APIs
+	polTests.Go(m.TestWithAWSCLIInAlpineContainer)
+	polTests.Go(m.TestWithAWSCLIInUbuntuContainer)
+
 	// From this point onwards, we're testing the specific functionality of the {{.module_name}} module.
 
 	if err := polTests.Wait(); err != nil {

--- a/module-template/clis.go
+++ b/module-template/clis.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 // WithAWSCLIInAlpineContainer installs the AWS CLI in the
 // Alpine-based container.
 // This method installs the AWS CLI in a golang/alpine container
@@ -18,17 +20,39 @@ func (m *ModuleTemplate) WithAWSCLIInAlpineContainer() *ModuleTemplate {
 
 // WithAWSCLIInUbuntuContainer installs the AWS CLI in the Ubuntu-based container.
 //
-// This method installs the AWS CLI in an Ubuntu-based
-// container using the 'apt-get' package manager.
-// It is particularly useful for environments that need to
-// interact with AWS services.
+// This method installs the AWS CLI in an Ubuntu-based container following the
+// official AWS installation steps.
+//
+// Args:
+//   - architecture (string): The architecture for which the AWS CLI should be downloaded.
+//     Valid values are "x86_64" and "aarch64". Default is "x86_64".
 //
 // Returns:
 //   - *ModuleTemplate: The updated ModuleTemplate with the AWS CLI installed in the container.
-func (m *ModuleTemplate) WithAWSCLIInUbuntuContainer() *ModuleTemplate {
+func (m *ModuleTemplate) WithAWSCLIInUbuntuContainer(
+	// architecture is the architecture for which the AWS CLI should be downloaded.
+	// Valid values are "x86_64" and "aarch64". Default is "x86_64".
+	// +optional
+	architecture string) *ModuleTemplate {
+	// Validate and default the architecture argument
+	switch architecture {
+	case "":
+		architecture = "x86_64"
+	case "aarch64", "x86_64":
+		// valid architectures
+	default:
+		panic("Invalid architecture specified. Supported values are 'x86_64' and 'aarch64'.")
+	}
+
+	url := fmt.Sprintf("https://awscli.amazonaws.com/awscli-exe-linux-%s.zip", architecture)
+
 	m.Ctr = m.Ctr.
 		WithExec([]string{"apt-get", "update"}).
-		WithExec([]string{"apt-get", "install", "-y", "awscli"})
+		WithExec([]string{"apt-get", "install", "-y", "unzip", "curl", "sudo"}).
+		WithExec([]string{"curl", "-L", url, "-o", "awscliv2.zip"}).
+		WithExec([]string{"unzip", "awscliv2.zip"}).
+		WithExec([]string{"sudo", "./aws/install"}).
+		WithExec([]string{"rm", "-rf", "awscliv2.zip", "aws"})
 
 	return m
 }

--- a/module-template/tests/cli.go
+++ b/module-template/tests/cli.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
+)
+
+// TestWithAWSCLIInAlpineContainer verifies that the AWS CLI is
+// correctly installed
+// inside an Alpine container, both in terms of binary location and version.
+//
+// It performs the following checks:
+// 1. Verifies if the AWS CLI binary is installed in the OS
+// filesystem using the `which aws` command.
+// 2. Confirms the AWS CLI version by executing `aws --version`.
+//
+// If any of these checks fail, the function returns an error detailing the failure.
+func (m *Tests) TestWithAWSCLIInAlpineContainer(ctx context.Context) error {
+	targetModule := dag.ModuleTemplate()
+
+	// Configure the target module to use AWS CLI in Alpine container
+	targetModule = targetModule.WithAwscliinAlpineContainer()
+	// Check if the AWS CLI binary is installed in the OS filesystem
+	out, whichErr := targetModule.
+		Ctr().
+		WithExec([]string{"which", "aws"}).
+		Stdout(ctx)
+
+	if whichErr != nil {
+		return WrapError(whichErr, "failed to get AWS CLI binary path")
+	}
+
+	if !strings.Contains(out, "/usr/bin/aws") {
+		return Errorf("expected AWS CLI binary to be in "+
+			"/usr/bin/aws, got %s", out)
+	}
+
+	// Check if the AWS CLI binary is installed and get its version
+	outVersion, errVersion := targetModule.
+		Ctr().
+		WithExec([]string{"aws", "--version"}).
+		Stdout(ctx)
+
+	if errVersion != nil {
+		return WrapError(errVersion, "failed to get AWS CLI version")
+	}
+
+	if !strings.Contains(outVersion, "aws-cli/2") {
+		return Errorf("expected AWS CLI version to be 2, got %s", outVersion)
+	}
+
+	return nil
+}
+
+// TestWithAWSCLIInUbuntuContainer verifies that the AWS CLI is
+// correctly installed inside an Ubuntu container, both in terms of
+// binary location and version.
+//
+// It performs the following checks:
+// 1. Verifies if the AWS CLI binary is installed in the OS
+// filesystem using the `which aws` command.
+// 2. Confirms the AWS CLI version by executing `aws --version`.
+//
+// If any of these checks fail, the function returns an error detailing the failure.
+func (m *Tests) TestWithAWSCLIInUbuntuContainer(ctx context.Context) error {
+	targetModule := dag.
+		ModuleTemplate().
+		BaseUbuntu()
+
+	// Configure the target module to use AWS CLI in Ubuntu container
+	targetModule = targetModule.
+		WithAwscliinUbuntuContainer(dagger.
+			ModuleTemplateWithAwscliinUbuntuContainerOpts{
+			Architecture: "x86_64",
+		})
+
+	// Check if the AWS CLI binary is installed in the OS filesystem
+	out, whichErr := targetModule.Ctr().
+		WithExec([]string{"which", "aws"}).
+		Stdout(ctx)
+
+	if whichErr != nil {
+		return WrapError(whichErr, "failed to get AWS CLI binary path")
+	}
+
+	if !strings.Contains(out, "/usr/local/bin/aws") {
+		return Errorf("expected AWS CLI binary to "+
+			"be in /usr/local/bin/aws, got %s", out)
+	}
+
+	// List on /usr/local/bin/aws
+	lsOut, lsErr := targetModule.Ctr().
+		WithExec([]string{"ls", "/usr/local/bin/aws"}).
+		Stdout(ctx)
+
+	if lsErr != nil {
+		return WrapError(lsErr, "failed to list /usr/local/bin/aws")
+	}
+
+	if !strings.Contains(lsOut, "aws") {
+		return Errorf("expected AWS CLI binary to be in /usr/local/bin/aws, got %s", lsOut)
+	}
+
+	return nil
+}

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -100,6 +100,10 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)
 
+	// Test CLIs APIs
+	polTests.Go(m.TestWithAWSCLIInAlpineContainer)
+	polTests.Go(m.TestWithAWSCLIInUbuntuContainer)
+
 	// From this point onwards, we're testing the specific functionality of the ModuleTemplate module.
 
 	if err := polTests.Wait(); err != nil {

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -100,7 +100,7 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)
 
-	// Test CLIs APIs
+	// Test CLI APIs
 	polTests.Go(m.TestWithAWSCLIInAlpineContainer)
 	polTests.Go(m.TestWithAWSCLIInUbuntuContainer)
 


### PR DESCRIPTION
Adds two new test functions to the `Tests` struct:

1. `TestWithAWSCLIInAlpineContainer`: Verifies that the AWS CLI is correctly installed inside an Alpine container, by checking the binary location and version.
2. `TestWithAWSCLIInUbuntuContainer`: Verifies that the AWS CLI is correctly installed inside an Ubuntu container, by checking the binary location and version.

These tests ensure that the AWS CLI is properly configured and available for use in the ModuleTemplate project.

Additionally, the `WithAWSCLIInUbuntuContainer` method in the `ModuleTemplate` struct has been updated to allow specifying the target architecture (x86_64 or aarch64) for the AWS CLI installation.