### PR TITLE
feat: Add support for Go private module configuration and GCC compiler installation

### DIFF
--- a/.daggerx/templates/module/golang.go.tmpl
+++ b/.daggerx/templates/module/golang.go.tmpl
@@ -429,3 +429,80 @@ func (m *{{.module_name}}) buildGoArgs(opts goBuildCmdOptions) []string {
 
 	return args
 }
+
+// WithGoPrivate configures the GOPRIVATE environment variable for the container environment.
+//
+// This method sets the GOPRIVATE variable, which is used by the Go toolchain to identify
+// private modules or repositories that should not be fetched from public proxies.
+//
+// Parameters:
+// - privateHost (string): The hostname of the private host for the Go packages or modules.
+//
+// Returns:
+// - *{{.module_name}}: A pointer to the updated {{.module_name}} instance.
+func (m *{{.module_name}}) WithGoPrivate(
+	// privateHost is the hostname of the private host for the Go packages or modules.
+	privateHost string,
+) *{{.module_name}} {
+	// Set the GOPRIVATE environment variable within the container
+	m.Ctr = m.Ctr.
+		WithExec(
+			[]string{"go", "env", "GOPRIVATE", privateHost},
+			dagger.ContainerWithExecOpts{
+				InsecureRootCapabilities: true,
+			},
+		).
+		WithEnvVariable("GOPRIVATE", privateHost)
+
+	return m
+}
+
+// WithGoGCCCompiler installs the GCC compiler and development tools in the container environment.
+//
+// This method uses the Alpine package manager (`apk`) to install the GCC compiler along
+// with `musl-dev`, which is the development package of the standard C library on Alpine.
+//
+// Example usage:
+//
+//	{{.module_name}}.WithGCCCompiler()
+//
+// Returns:
+// - *{{.module_name}}: A pointer to the updated {{.module_name}} instance.
+func (m *{{.module_name}}) WithGoGCCCompiler() *{{.module_name}} {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apk", "add", "--no-cache", "gcc", "musl-dev"})
+
+	return m
+}
+
+// WithGoTestSum installs the GoTestSum tool and its dependency `tparse` in the container environment.
+//
+// This method installs `gotest.tools/gotestsum` and `github.com/mfridman/tparse`
+// using the specified version. If no version is provided, it defaults to "latest".
+//
+// Parameters:
+//   - version (string) +optional: The version of GoTestSum to use, e.g., "v0.8.0".
+//     If empty, it defaults to "latest".
+//
+// Example:
+//
+//	m := &{{.module_name}}{}
+//	m.WithGoTestSum("v0.8.0") // Install specific version
+//	m.WithGoTestSum("")        // Install latest version
+//
+// Returns:
+// - *{{.module_name}}: A pointer to the updated {{.module_name}} instance.
+func (m *{{.module_name}}) WithGoTestSum(
+	// version is the version of GoTestSum to use, e.g., "v0.8.0".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	if version == "" {
+		version = defaultContainerVersion
+	}
+
+	return m.WithGoInstall([]string{
+		"gotest.tools/gotestsum@" + version,
+		"github.com/mfridman/tparse@" + version,
+	})
+}

--- a/.daggerx/templates/tests/golang.go.tmpl
+++ b/.daggerx/templates/tests/golang.go.tmpl
@@ -504,3 +504,149 @@ func (m *Tests) TestGoWithGoBuild(ctx context.Context) error {
 
 	return nil
 }
+
+// TestGoWithGoPrivate tests the configuration of the GOPRIVATE environment variable
+// using the WithGoPrivate method. It ensures that the GOPRIVATE environment variable
+// is set correctly within the specified context.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Configures the GOPRIVATE environment variable to the specified value.
+// 3. Executes the `go env GOPRIVATE` command to retrieve the GOPRIVATE environment variable.
+// 4. Validates that the GOPRIVATE environment variable is set to the expected value.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+// - error: If any of the steps fail, an error is returned indicating what went wrong.
+func (m *Tests) TestGoWithGoPrivate(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.{{.module_name}}(
+		dagger.{{.module_name}}Opts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Set the GOPRIVATE environment variable to the specified value.
+	targetModule = targetModule.
+		WithGoPrivate("github.com/Excoriate")
+
+	// Execute the `go env GOPRIVATE` command to retrieve the GOPRIVATE environment variable.
+	envOut, err := targetModule.Ctr().
+		WithExec([]string{"go", "env", "GOPRIVATE"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get GOPRIVATE environment variable")
+	}
+
+	// Validate that the GOPRIVATE environment variable is set to the expected value.
+	if envOut == "" {
+		return Errorf("expected to have at least one folder, got empty output")
+	}
+
+	if !strings.Contains(envOut, "github.com/Excoriate") {
+		return WrapErrorf(err, "expected GOPRIVATE to be set "+
+			"to github.com/Excoriate, got %s", envOut)
+	}
+
+	return nil
+}
+
+// TestGoWithGCCCompiler verifies the installation and presence of the GCC compiler
+// within the specified context, using the provided Alpine container setup.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Installs the GCC compiler and associated development tools.
+// 3. Executes the `gcc --version` command to verify the GCC compiler installation.
+// 4. Validates the output to confirm the presence of the GCC compiler.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+//   - error: If any of the installation or verification steps fail, an error is returned
+//     indicating what went wrong.
+func (m *Tests) TestGoWithGCCCompiler(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.{{.module_name}}(
+		dagger.{{.module_name}}Opts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Install the GCC compiler and development tools.
+	targetModule = targetModule.
+		WithGoGcccompiler()
+
+	// Execute the `gcc --version` command to check if the GCC compiler is installed.
+	cmdOut, cmdErr := targetModule.Ctr().
+		WithExec([]string{"gcc", "--version"}).
+		Stdout(ctx)
+
+	if cmdErr != nil {
+		return WrapError(cmdErr, "failed to run gcc --version command")
+	}
+
+	// Validate that the GCC compiler is installed.
+	if cmdOut == "" {
+		return Errorf("expected to have output when running gcc --version, " +
+			"got empty output")
+	}
+
+	if !strings.Contains(cmdOut, "gcc") {
+		return Errorf("expected to have found gcc in the output, got %s", cmdOut)
+	}
+
+	return nil
+}
+
+// TestGoWithGoTestSum verifies the installation and presence of the GoTestSum tool
+// within the specified context, using the provided Alpine container setup.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Installs the GoTestSum tool and its dependency `tparse` in the container.
+// 3. Executes the `gotestsum --version` command to verify the GoTestSum tool installation.
+// 4. Validates the output to confirm the presence of the GoTestSum tool.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+//   - error: If any of the installation or verification steps fail, an error is returned
+//     indicating what went wrong.
+func (m *Tests) TestGoWithGoTestSum(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.{{.module_name}}(
+		dagger.{{.module_name}}Opts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Install the GoTestSum tool and its dependency `tparse` in the container.
+	targetModule = targetModule.
+		WithGoTestSum()
+
+	// Execute the `gotestsum --version` command to check if the GoTestSum tool is installed.
+	cmdOut, cmdErr := targetModule.Ctr().
+		WithExec([]string{"gotestsum", "--version"}).
+		Stdout(ctx)
+
+	if cmdErr != nil {
+		return WrapError(cmdErr, "failed to run gotestsum --version command")
+	}
+
+	// Validate that the GoTestSum tool is installed.
+	if cmdOut == "" {
+		return Errorf("expected to have output when running gotestsum --version, got empty output")
+	}
+
+	if !strings.Contains(cmdOut, "gotestsum") {
+		return Errorf("expected to have found gotestsum in the output, got %s", cmdOut)
+	}
+
+	return nil
+}

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -96,6 +96,9 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestGoWithCgoDisabled)
 	polTests.Go(m.TestGoWithGoExec)
 	polTests.Go(m.TestGoWithGoInstall)
+	polTests.Go(m.TestGoWithGoPrivate)
+	polTests.Go(m.TestGoWithGCCCompiler)
+	polTests.Go(m.TestGoWithGoTestSum)
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)

--- a/module-template/tests/golang.go
+++ b/module-template/tests/golang.go
@@ -504,3 +504,149 @@ func (m *Tests) TestGoWithGoBuild(ctx context.Context) error {
 
 	return nil
 }
+
+// TestGoWithGoPrivate tests the configuration of the GOPRIVATE environment variable
+// using the WithGoPrivate method. It ensures that the GOPRIVATE environment variable
+// is set correctly within the specified context.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Configures the GOPRIVATE environment variable to the specified value.
+// 3. Executes the `go env GOPRIVATE` command to retrieve the GOPRIVATE environment variable.
+// 4. Validates that the GOPRIVATE environment variable is set to the expected value.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+// - error: If any of the steps fail, an error is returned indicating what went wrong.
+func (m *Tests) TestGoWithGoPrivate(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.ModuleTemplate(
+		dagger.ModuleTemplateOpts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Set the GOPRIVATE environment variable to the specified value.
+	targetModule = targetModule.
+		WithGoPrivate("github.com/Excoriate")
+
+	// Execute the `go env GOPRIVATE` command to retrieve the GOPRIVATE environment variable.
+	envOut, err := targetModule.Ctr().
+		WithExec([]string{"go", "env", "GOPRIVATE"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get GOPRIVATE environment variable")
+	}
+
+	// Validate that the GOPRIVATE environment variable is set to the expected value.
+	if envOut == "" {
+		return Errorf("expected to have at least one folder, got empty output")
+	}
+
+	if !strings.Contains(envOut, "github.com/Excoriate") {
+		return WrapErrorf(err, "expected GOPRIVATE to be set "+
+			"to github.com/Excoriate, got %s", envOut)
+	}
+
+	return nil
+}
+
+// TestGoWithGCCCompiler verifies the installation and presence of the GCC compiler
+// within the specified context, using the provided Alpine container setup.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Installs the GCC compiler and associated development tools.
+// 3. Executes the `gcc --version` command to verify the GCC compiler installation.
+// 4. Validates the output to confirm the presence of the GCC compiler.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+//   - error: If any of the installation or verification steps fail, an error is returned
+//     indicating what went wrong.
+func (m *Tests) TestGoWithGCCCompiler(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.ModuleTemplate(
+		dagger.ModuleTemplateOpts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Install the GCC compiler and development tools.
+	targetModule = targetModule.
+		WithGoGcccompiler()
+
+	// Execute the `gcc --version` command to check if the GCC compiler is installed.
+	cmdOut, cmdErr := targetModule.Ctr().
+		WithExec([]string{"gcc", "--version"}).
+		Stdout(ctx)
+
+	if cmdErr != nil {
+		return WrapError(cmdErr, "failed to run gcc --version command")
+	}
+
+	// Validate that the GCC compiler is installed.
+	if cmdOut == "" {
+		return Errorf("expected to have output when running gcc --version, " +
+			"got empty output")
+	}
+
+	if !strings.Contains(cmdOut, "gcc") {
+		return Errorf("expected to have found gcc in the output, got %s", cmdOut)
+	}
+
+	return nil
+}
+
+// TestGoWithGoTestSum verifies the installation and presence of the GoTestSum tool
+// within the specified context, using the provided Alpine container setup.
+//
+// This function performs the following steps:
+// 1. Sets up the Go module container using the default module template.
+// 2. Installs the GoTestSum tool and its dependency `tparse` in the container.
+// 3. Executes the `gotestsum --version` command to verify the GoTestSum tool installation.
+// 4. Validates the output to confirm the presence of the GoTestSum tool.
+//
+// Parameters:
+// - ctx: The context to control the execution.
+//
+// Returns:
+//   - error: If any of the installation or verification steps fail, an error is returned
+//     indicating what went wrong.
+func (m *Tests) TestGoWithGoTestSum(ctx context.Context) error {
+	// Setting up the Go module container using the default module template.
+	targetModule := dag.ModuleTemplate(
+		dagger.ModuleTemplateOpts{
+			Ctr: getGolangAlpineContainer(""),
+		},
+	)
+
+	// Install the GoTestSum tool and its dependency `tparse` in the container.
+	targetModule = targetModule.
+		WithGoTestSum()
+
+	// Execute the `gotestsum --version` command to check if the GoTestSum tool is installed.
+	cmdOut, cmdErr := targetModule.Ctr().
+		WithExec([]string{"gotestsum", "--version"}).
+		Stdout(ctx)
+
+	if cmdErr != nil {
+		return WrapError(cmdErr, "failed to run gotestsum --version command")
+	}
+
+	// Validate that the GoTestSum tool is installed.
+	if cmdOut == "" {
+		return Errorf("expected to have output when running gotestsum --version, got empty output")
+	}
+
+	if !strings.Contains(cmdOut, "gotestsum") {
+		return Errorf("expected to have found gotestsum in the output, got %s", cmdOut)
+	}
+
+	return nil
+}

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -96,6 +96,9 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestGoWithCgoDisabled)
 	polTests.Go(m.TestGoWithGoExec)
 	polTests.Go(m.TestGoWithGoInstall)
+	polTests.Go(m.TestGoWithGoPrivate)
+	polTests.Go(m.TestGoWithGCCCompiler)
+	polTests.Go(m.TestGoWithGoTestSum)
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)


### PR DESCRIPTION
This commit introduces two new methods to the `ModuleTemplate` struct:

1. `WithGoPrivate(privateHost string)`: This method sets the `GOPRIVATE` environment variable within the container, which is used by the Go toolchain to identify private modules or repositories that should not be fetched from public proxies.

2. `WithGoGCCCompiler()`: This method installs the GCC compiler and development tools (specifically, `musl-dev`) in the container environment using the Alpine package manager (`apk`).

Additionally, this commit adds two new test functions to the `Tests` struct:

1. `TestGoWithGoPrivate(ctx context.Context)`: This function tests the configuration of the `GOPRIVATE` environment variable using the `WithGoPrivate` method.

2. `TestGoWithGCCCompiler(ctx context.Context)`: This function verifies the installation and presence of the GCC compiler within the specified context, using the provided Alpine container setup.

These changes enhance the flexibility and functionality of the `ModuleTemplate` and `Tests` structs, allowing users to configure the Go private module settings and install the GCC compiler as needed for their development requirements.