### PR TITLE
feat: Add Terraform installation and verification functionality

### DIFF
--- a/.daggerx/templates/module/iac_terraform.go.tmpl
+++ b/.daggerx/templates/module/iac_terraform.go.tmpl
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/internal/dagger"
+)
+
+const (
+	latestVersion       = "latest"
+	terraformReleaseURL = "https://releases.hashicorp.com/terraform"
+	hashicorpGPGURL     = "https://apt.releases.hashicorp.com/gpg"
+	hashicorpRepoURL    = "https://apt.releases.hashicorp.com"
+)
+
+// resolveTerraformVersion resolves the provided version to "latest" if it's empty.
+func resolveTerraformVersion(version string) string {
+	if version == "" {
+		return latestVersion
+	}
+
+	return version
+}
+
+// getLatestTerraformVersion fetches the latest Terraform version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerraformVersion() string {
+	// Placeholder: In reality, you'd fetch this from Terraform's releases page or API
+	return "1.9.4" // Example latest version
+}
+
+// WithTerraformUbuntu sets up the container with Terraform on Ubuntu.
+// It updates the package list, installs required dependencies, and then installs the specified version of Terraform.
+//
+// Parameters:
+// version - The version of Terraform to install. If empty, "latest" will be installed.
+func (m *{{.module_name}}) WithTerraformUbuntu(
+	// version is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	version = resolveTerraformVersion(version)
+	if version == latestVersion {
+		version = getLatestTerraformVersion()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesUbuntu()
+
+	m.Ctr = m.downloadAndInstallTerraform(version)
+
+	return m.verifyTerraformInstallation()
+}
+
+// WithTerraformAlpine sets up the container with Terraform on Alpine Linux.
+// It updates the package list, installs required dependencies, and then installs the
+// specified version of Terraform.
+//
+// Parameters:
+// version - The version of Terraform to install. If empty, "latest" will be installed.
+func (m *{{.module_name}}) WithTerraformAlpine(
+	// version is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	version = resolveTerraformVersion(version)
+	if version == latestVersion {
+		version = getLatestTerraformVersion()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesAlpine()
+
+	m.Ctr = m.downloadAndInstallTerraform(version)
+
+	return m.verifyTerraformInstallation()
+}
+
+func (m *{{.module_name}}) downloadAndInstallTerraform(version string) *dagger.Container {
+	terraformURL := terraformReleaseURL + "/" + version + "/terraform_" + version + "_linux_amd64.zip"
+	zipFile := "terraform_" + version + "_linux_amd64.zip"
+
+	return m.Ctr.
+		WithExec([]string{"wget", terraformURL}).
+		WithExec([]string{"unzip", zipFile}).
+		WithExec([]string{"rm", zipFile}).
+		WithExec([]string{"mv", "terraform", "/usr/local/bin"}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/terraform"})
+}
+
+func (m *{{.module_name}}) verifyTerraformInstallation() *{{.module_name}} {
+	m.Ctr = m.Ctr.WithExec([]string{"terraform", "version"})
+
+	return m
+}
+
+func (m *{{.module_name}}) downloadRequiredUtilitiesAlpine() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apk", "update"}).
+		WithExec([]string{"apk", "add", "curl", "wget", "bash", "unzip", "yq"})
+}
+
+func (m *{{.module_name}}) downloadRequiredUtilitiesUbuntu() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "unzip"})
+}

--- a/.daggerx/templates/tests/iac_terraform.go.tmpl
+++ b/.daggerx/templates/tests/iac_terraform.go.tmpl
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+)
+
+// TestIACWithTerraformAlpine checks the installation, PATH inclusion, and functionality of Terraform
+// on an Alpine Linux environment across various Terraform versions.
+//
+// It verifies Terraform installation by running `terraform version`, ensures
+// Terraform is in the system PATH by using `which terraform`, and tests that
+// Terraform commands work correctly by running `terraform --help`.
+//
+// Args:
+//
+//	ctx: Context to control execution.
+//	version: List of Terraform versions to test. An empty string implies the latest version.
+//
+// Returns:
+//
+//	An error if any of the Terraform checks fail for any version; otherwise, nil.
+func (m *Tests) TestIACWithTerraformAlpine(ctx context.Context) error {
+	// List of Terraform versions to test. An empty string implies the latest version.
+	versions := []string{"", "1.0.0", "1.9.4", "1.8.0"}
+
+	for _, version := range versions {
+		// Initialize the module with the specified Terraform version on Alpine Linux.
+		targetModule := dag.
+			{{.module_name}}().
+			WithTerraformAlpine(dagger.
+				{{.module_name}}WithTerraformAlpineOpts{
+				Version: version,
+			})
+
+		// Verify the installation of Terraform.
+		if err := m.verifyTerraformInstallation(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify that Terraform is in the system PATH.
+		if err := m.verifyTerraformInPath(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify the functionality of Terraform by running the help command.
+		if err := m.verifyTerraformHelp(ctx, targetModule, version); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformInstallation(ctx context.Context, module *dagger.{{.module_name}}, version string) error {
+	versionOut, err := module.
+		Ctr().
+		WithExec([]string{"terraform", "version"}).Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to run terraform version command for version "+version)
+	}
+
+	if versionOut == "" {
+		return Errorf("expected to have terraform version output, got empty output for version %s", version)
+	}
+
+	if !strings.Contains(versionOut, "Terraform v") {
+		return Errorf("expected Terraform to be working correctly, got %s for version %s", versionOut, version)
+	}
+
+	if version != "" && !strings.Contains(versionOut, "Terraform v"+version) {
+		return Errorf("expected Terraform version %s, got %s", version, versionOut)
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformInPath(ctx context.Context, module *dagger.{{.module_name}}, version string) error {
+	pathOut, err := module.Ctr().WithExec([]string{"which", "terraform"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to find terraform in PATH for version "+version)
+	}
+
+	if pathOut == "" {
+		return Errorf("expected to have terraform in PATH, got empty output for version %s", version)
+	}
+
+	// Trim any whitespace from the pathOut
+	pathOut = strings.TrimSpace(pathOut)
+
+	// Use the path to check if in the filesystem
+	_, err = module.Ctr().WithExec([]string{"ls", "-l", pathOut}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to find terraform in filesystem for version "+version)
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformHelp(ctx context.Context, module *dagger.{{.module_name}}, version string) error {
+	helpOut, err := module.Ctr().WithExec([]string{"terraform", "--help"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to run terraform help command for version "+version)
+	}
+
+	if helpOut == "" {
+		return Errorf("expected to have terraform help output, got empty output for version %s", version)
+	}
+
+	if !strings.Contains(helpOut, "Usage: terraform") {
+		return Errorf("expected Terraform to be working correctly, got %s for version %s", helpOut, version)
+	}
+
+	return nil
+}
+
+// TestIACWithTerraformUbuntu checks the installation, PATH inclusion, and functionality of Terraform
+// on an Ubuntu Linux environment across various Terraform versions.
+//
+// It verifies Terraform installation by running `terraform version`, ensures Terraform is in
+// the system PATH by using `which terraform`, and tests that Terraform commands work correctly
+// by running `terraform --help`.
+//
+// Args:
+//
+//	ctx: Context to control execution.
+//	version: List of Terraform versions to test. An empty string implies the latest version.
+//
+// Returns:
+//
+//	An error if any of the Terraform checks fail for any version; otherwise, nil.
+func (m *Tests) TestIACWithTerraformUbuntu(ctx context.Context) error {
+	// Set up Ubuntu container.
+	ubuntuCtr := dag.Container().From("ubuntu:latest")
+
+	// List of Terraform versions to test. An empty string implies the latest version.
+	versions := []string{"", "1.0.0", "1.9.0", "1.8.0"}
+
+	for _, version := range versions {
+		// Initialize the module with the specified Terraform version on Ubuntu.
+		targetModule := dag.
+			{{.module_name}}(dagger.{{.module_name}}Opts{
+				Ctr: ubuntuCtr,
+			}).
+			WithTerraformUbuntu(dagger.{{.module_name}}WithTerraformUbuntuOpts{
+				Version: version,
+			})
+
+		// Verify the installation of Terraform.
+		if err := m.verifyTerraformInstallation(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify that Terraform is in the system PATH.
+		if err := m.verifyTerraformInPath(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify the functionality of Terraform by running the help command.
+		if err := m.verifyTerraformHelp(ctx, targetModule, version); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -102,10 +102,12 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)
-
 	// Test CLI APIs
 	polTests.Go(m.TestWithAWSCLIInAlpineContainer)
 	polTests.Go(m.TestWithAWSCLIInUbuntuContainer)
+	// Test IAC specific functions.
+	polTests.Go(m.TestIACWithTerraformUbuntu)
+	polTests.Go(m.TestIACWithTerraformAlpine)
 
 	// From this point onwards, we're testing the specific functionality of the {{.module_name}} module.
 

--- a/module-template/iac_terraform.go
+++ b/module-template/iac_terraform.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
+)
+
+const (
+	latestVersion       = "latest"
+	terraformReleaseURL = "https://releases.hashicorp.com/terraform"
+	hashicorpGPGURL     = "https://apt.releases.hashicorp.com/gpg"
+	hashicorpRepoURL    = "https://apt.releases.hashicorp.com"
+)
+
+// resolveTerraformVersion resolves the provided version to "latest" if it's empty.
+func resolveTerraformVersion(version string) string {
+	if version == "" {
+		return latestVersion
+	}
+
+	return version
+}
+
+// getLatestTerraformVersion fetches the latest Terraform version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerraformVersion() string {
+	// Placeholder: In reality, you'd fetch this from Terraform's releases page or API
+	return "1.9.4" // Example latest version
+}
+
+// WithTerraformUbuntu sets up the container with Terraform on Ubuntu.
+// It updates the package list, installs required dependencies, and then installs the specified version of Terraform.
+//
+// Parameters:
+// version - The version of Terraform to install. If empty, "latest" will be installed.
+func (m *ModuleTemplate) WithTerraformUbuntu(
+	// version is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	version = resolveTerraformVersion(version)
+	if version == latestVersion {
+		version = getLatestTerraformVersion()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesUbuntu()
+
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "gnupg", "software-properties-common"}).
+		WithExec(m.getGPGKeyCommand()).
+		WithExec(m.getAddRepoCommand()).
+		WithExec([]string{"apt-get", "update"})
+
+	m.Ctr = m.installTerraformUbuntu(version)
+
+	return m.verifyTerraformInstallation()
+}
+
+func (m *ModuleTemplate) getGPGKeyCommand() []string {
+	command := fmt.Sprintf("wget -O- %s | gpg --dearmor | "+
+		"tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null", hashicorpGPGURL)
+
+	return []string{"bash", "-c", command}
+}
+
+func (m *ModuleTemplate) getAddRepoCommand() []string {
+	distro := "$(lsb_release -cs)"
+	repoLine := fmt.Sprintf(
+		`echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] %s %s main"`,
+		hashicorpRepoURL, distro,
+	)
+
+	command := repoLine + " | tee /etc/apt/sources.list.d/hashicorp.list"
+
+	return []string{"bash", "-c", command}
+}
+
+func (m *ModuleTemplate) installTerraformUbuntu(version string) *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apt-get", "install", "-y", "terraform=" + version})
+}
+
+// WithTerraformAlpine sets up the container with Terraform on Alpine Linux.
+// It updates the package list, installs required dependencies, and then installs the
+// specified version of Terraform.
+//
+// Parameters:
+// version - The version of Terraform to install. If empty, "latest" will be installed.
+func (m *ModuleTemplate) WithTerraformAlpine(
+	// version is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	version = resolveTerraformVersion(version)
+	if version == latestVersion {
+		version = getLatestTerraformVersion()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesAlpine()
+
+	m.Ctr = m.downloadAndInstallTerraform(version)
+
+	return m.verifyTerraformInstallation()
+}
+
+func (m *ModuleTemplate) downloadAndInstallTerraform(version string) *dagger.Container {
+	terraformURL := fmt.Sprintf("%s/%s/terraform_%s_linux_amd64.zip",
+		terraformReleaseURL, version, version)
+
+	zipFile := fmt.Sprintf("terraform_%s_linux_amd64.zip", version)
+
+	return m.Ctr.
+		WithExec([]string{"wget", terraformURL}).
+		WithExec([]string{"unzip", zipFile}).
+		WithExec([]string{"rm", zipFile}).
+		WithExec([]string{"mv", "terraform", "/usr/local/bin"})
+}
+
+func (m *ModuleTemplate) verifyTerraformInstallation() *ModuleTemplate {
+	m.Ctr = m.Ctr.WithExec([]string{"terraform", "version"})
+
+	return m
+}
+
+func (m *ModuleTemplate) downloadRequiredUtilitiesAlpine() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apk", "update"}).
+		WithExec([]string{"apk", "add", "curl", "wget", "bash", "unzip", "yq"})
+}
+
+func (m *ModuleTemplate) downloadRequiredUtilitiesUbuntu() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "bash", "unzip", "yq"})
+}

--- a/module-template/tests/iac_terraform.go
+++ b/module-template/tests/iac_terraform.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
+)
+
+// TestIACWithTerraformAlpine checks the installation, PATH inclusion, and functionality of Terraform
+// on an Alpine Linux environment across various Terraform versions.
+//
+// It verifies Terraform installation by running `terraform version`, ensures
+// Terraform is in the system PATH by using `which terraform`, and tests that
+// Terraform commands work correctly by running `terraform --help`.
+//
+// Args:
+//
+//	ctx: Context to control execution.
+//	version: List of Terraform versions to test. An empty string implies the latest version.
+//
+// Returns:
+//
+//	An error if any of the Terraform checks fail for any version; otherwise, nil.
+func (m *Tests) TestIACWithTerraformAlpine(ctx context.Context) error {
+	// List of Terraform versions to test. An empty string implies the latest version.
+	versions := []string{"", "1.0.0", "1.9.4", "1.8.0"}
+
+	for _, version := range versions {
+		// Initialize the module with the specified Terraform version on Alpine Linux.
+		targetModule := dag.
+			ModuleTemplate().
+			WithTerraformAlpine(dagger.
+				ModuleTemplateWithTerraformAlpineOpts{
+				Version: version,
+			})
+
+		// Verify the installation of Terraform.
+		if err := m.verifyTerraformInstallation(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify that Terraform is in the system PATH.
+		if err := m.verifyTerraformInPath(ctx, targetModule, version); err != nil {
+			return err
+		}
+
+		// Verify the functionality of Terraform by running the help command.
+		if err := m.verifyTerraformHelp(ctx, targetModule, version); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformInstallation(ctx context.Context, module *dagger.ModuleTemplate, version string) error {
+	versionOut, err := module.
+		Ctr().
+		WithExec([]string{"terraform", "version"}).Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to run terraform version command for version "+version)
+	}
+
+	if versionOut == "" {
+		return Errorf("expected to have terraform version output, got empty output for version %s", version)
+	}
+
+	if !strings.Contains(versionOut, "Terraform v") {
+		return Errorf("expected Terraform to be working correctly, got %s for version %s", versionOut, version)
+	}
+
+	if version != "" && !strings.Contains(versionOut, "Terraform v"+version) {
+		return Errorf("expected Terraform version %s, got %s", version, versionOut)
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformInPath(ctx context.Context, module *dagger.ModuleTemplate, version string) error {
+	pathOut, err := module.Ctr().WithExec([]string{"which", "terraform"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to find terraform in PATH for version "+version)
+	}
+
+	if pathOut == "" {
+		return Errorf("expected to have terraform in PATH, got empty output for version %s", version)
+	}
+
+	// Trim any whitespace from the pathOut
+	pathOut = strings.TrimSpace(pathOut)
+
+	// Use the path to check if in the filesystem
+	_, err = module.Ctr().WithExec([]string{"ls", "-l", pathOut}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to find terraform in filesystem for version "+version)
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyTerraformHelp(ctx context.Context, module *dagger.ModuleTemplate, version string) error {
+	helpOut, err := module.Ctr().WithExec([]string{"terraform", "--help"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to run terraform help command for version "+version)
+	}
+
+	if helpOut == "" {
+		return Errorf("expected to have terraform help output, got empty output for version %s", version)
+	}
+
+	if !strings.Contains(helpOut, "Usage: terraform") {
+		return Errorf("expected Terraform to be working correctly, got %s for version %s", helpOut, version)
+	}
+
+	return nil
+}

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -102,10 +102,12 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)
-
 	// Test CLI APIs
 	polTests.Go(m.TestWithAWSCLIInAlpineContainer)
 	polTests.Go(m.TestWithAWSCLIInUbuntuContainer)
+	// Test IAC specific functions.
+	polTests.Go(m.TestIACWithTerraformUbuntu)
+	polTests.Go(m.TestIACWithTerraformAlpine)
 
 	// From this point onwards, we're testing the specific functionality of the ModuleTemplate module.
 


### PR DESCRIPTION
Adds the following functionality to the `ModuleTemplate` struct:
- `WithTerraformUbuntu` method to install Terraform on an Ubuntu-based container
- `WithTerraformAlpine` method to install Terraform on an Alpine Linux-based container
- Utility methods to fetch the latest Terraform version, resolve the provided version, and download and install Terraform
- Verification of the Terraform installation by running the `terraform version` command

These changes enhance the module's capabilities by providing a consistent way to set up Terraform in different Linux distributions, making it more versatile and maintainable.