### PR TITLE
fix: Update Dagger engine version in tests

### DIFF
--- a/module-template/tests/dagger.json
+++ b/module-template/tests/dagger.json
@@ -14,5 +14,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.5"
 }


### PR DESCRIPTION
The changes in this commit update the `engineVersion` field in the `dagger.json` file used for testing. The version is changed from `v0.12.4` to `v0.12.5`.