### PR TITLE
feat: Add Terragrunt support to the module template

### DIFF
--- a/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
+++ b/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.4, 0.12.5]
+                dagversion: [0.12.5]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest

--- a/.daggerx/templates/module/iac_terraform.go.tmpl
+++ b/.daggerx/templates/module/iac_terraform.go.tmpl
@@ -7,8 +7,6 @@ import (
 const (
 	latestVersion       = "latest"
 	terraformReleaseURL = "https://releases.hashicorp.com/terraform"
-	hashicorpGPGURL     = "https://apt.releases.hashicorp.com/gpg"
-	hashicorpRepoURL    = "https://apt.releases.hashicorp.com"
 )
 
 // resolveTerraformVersion resolves the provided version to "latest" if it's empty.

--- a/.daggerx/templates/module/iac_terragrunt.go.tmpl
+++ b/.daggerx/templates/module/iac_terragrunt.go.tmpl
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/internal/dagger"
+)
+
+const (
+	terragruntLatestVersion          = "latest"
+	terragruntReleaseURL             = "https://github.com/gruntwork-io/terragrunt/releases/download"
+	terragruntDefaultVer             = "v0.66.8"
+	terraformReleaseURLForTerragrunt = "https://releases.hashicorp.com/terraform"
+	terraformDefaultVer              = "1.9.4"
+)
+
+// resolveTerragruntVersion resolves the provided version to "latest" if it's empty.
+func resolveTerragruntVersion(version string) string {
+	if version == "" || version == terragruntLatestVersion {
+		return getLatestTerragruntVersion()
+	}
+
+	return version
+}
+
+// resolveTerraformVersionInTerragrunt resolves the provided version to "latest" if it's empty.
+func resolveTerraformVersionInTerragrunt(version string) string {
+	if version == "" {
+		return terragruntLatestVersion
+	}
+
+	return version
+}
+
+// getLatestTerragruntVersion fetches the latest Terragrunt version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerragruntVersion() string {
+	// Placeholder: In reality, you'd fetch this from Terragrunt's releases page or API
+	return terragruntDefaultVer
+}
+
+// getLatestTerraformVersionInTerragrunt fetches the latest Terraform version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerraformVersionInTerragrunt() string {
+	// Placeholder: In reality, you'd fetch this from Terraform's releases page or API
+	return terraformDefaultVer
+}
+
+// WithTerragruntUbuntu sets up the container with Terragrunt and optionally Terraform on Ubuntu.
+// It updates the package list, installs required dependencies, and then installs
+// the specified versions of Terragrunt and Terraform.
+//
+// Parameters:
+// version - The version of Terragrunt to install. If empty, "latest" will be installed.
+// tfVersion - The version of Terraform to install. If empty, "latest" will be installed.
+// skipTerraform - If true, Terraform installation will be skipped.
+func (m *{{.module_name}}) WithTerragruntUbuntu(
+	// version is the version of Terragrunt to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+	// tfVersion is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	tfVersion string,
+	// skipTerraform if true, Terraform installation will be skipped.
+	// +optional
+	skipTerraform bool,
+) *{{.module_name}} {
+	version = resolveTerragruntVersion(version)
+	if version == terragruntLatestVersion {
+		version = getLatestTerragruntVersion()
+	}
+
+	tfVersion = resolveTerraformVersionInTerragrunt(tfVersion)
+	if tfVersion == terragruntLatestVersion {
+		tfVersion = getLatestTerraformVersionInTerragrunt()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesTerragruntUbuntu()
+	m.Ctr = m.downloadAndInstallTerragrunt(version)
+
+	if !skipTerraform {
+		m.Ctr = m.downloadAndInstallTerraformInTerragrunt(tfVersion)
+	}
+
+	return m.verifyTerragruntInstallation()
+}
+
+// WithTerragruntAlpine sets up the container with Terragrunt and optionally Terraform on Alpine Linux.
+// It updates the package list, installs required dependencies, and then installs
+// the specified versions of Terragrunt and Terraform.
+//
+// Parameters:
+// version - The version of Terragrunt to install. If empty, "latest" will be installed.
+// tfVersion - The version of Terraform to install. If empty, "latest" will be installed.
+// skipTerraform - If true, Terraform installation will be skipped.
+func (m *{{.module_name}}) WithTerragruntAlpine(
+	// version is the version of Terragrunt to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+	// tfVersion is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	tfVersion string,
+	// skipTerraform if true, Terraform installation will be skipped.
+	// +optional
+	skipTerraform bool,
+) *{{.module_name}} {
+	version = resolveTerragruntVersion(version)
+	if version == terragruntLatestVersion {
+		version = getLatestTerragruntVersion()
+	}
+
+	tfVersion = resolveTerraformVersionInTerragrunt(tfVersion)
+	if tfVersion == terragruntLatestVersion {
+		tfVersion = getLatestTerraformVersionInTerragrunt()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesTerragruntAlpine()
+	m.Ctr = m.downloadAndInstallTerragrunt(version)
+
+	if !skipTerraform {
+		m.Ctr = m.downloadAndInstallTerraformInTerragrunt(tfVersion)
+	}
+
+	return m.verifyTerragruntInstallation()
+}
+
+func (m *{{.module_name}}) downloadAndInstallTerragrunt(version string) *dagger.Container {
+	// Remove "v" prefix if present
+	version = strings.TrimPrefix(version, "v")
+	terragruntURL := fmt.Sprintf("%s/v%s/terragrunt_linux_amd64", terragruntReleaseURL, version)
+
+	return m.Ctr.
+		WithExec([]string{"wget", "-q", "-O", "/usr/local/bin/terragrunt", terragruntURL}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/terragrunt"})
+}
+
+func (m *{{.module_name}}) downloadAndInstallTerraformInTerragrunt(version string) *dagger.Container {
+	terraformURL := fmt.Sprintf("%s/%s/terraform_%s_linux_amd64.zip", terraformReleaseURLForTerragrunt, version, version)
+
+	return m.Ctr.
+		WithExec([]string{"wget", "-q", terraformURL}).
+		WithExec([]string{"unzip", fmt.Sprintf("terraform_%s_linux_amd64.zip", version)}).
+		WithExec([]string{"mv", "terraform", "/usr/local/bin/"}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/terraform"}).
+		WithExec([]string{"rm", fmt.Sprintf("terraform_%s_linux_amd64.zip", version)})
+}
+
+func (m *{{.module_name}}) verifyTerragruntInstallation() *{{.module_name}} {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"terragrunt", "--version"}).
+		WithExec([]string{"terraform", "version"})
+
+	return m
+}
+
+func (m *{{.module_name}}) downloadRequiredUtilitiesTerragruntAlpine() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apk", "update"}).
+		WithExec([]string{"apk", "add", "--no-cache", "curl", "wget", "unzip"})
+}
+
+func (m *{{.module_name}}) downloadRequiredUtilitiesTerragruntUbuntu() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "unzip"})
+}

--- a/.daggerx/templates/tests/iac_terragrunt.go.tmpl
+++ b/.daggerx/templates/tests/iac_terragrunt.go.tmpl
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+)
+
+// TestIACWithTerragruntAlpine tests Terragrunt installation on Alpine.
+func (m *Tests) TestIACWithTerragruntAlpine(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}(dagger.{{.module_name}}Opts{
+		Ctr: dag.
+			Container().
+			From("alpine:latest").
+			WithExec([]string{"apk", "add", "curl"}),
+	})
+
+	return m.testTerragruntVersions(ctx, targetModule, true)
+}
+
+// TestIACWithTerragruntUbuntu tests Terragrunt installation on Ubuntu.
+func (m *Tests) TestIACWithTerragruntUbuntu(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}(dagger.{{.module_name}}Opts{
+		Ctr: dag.
+			Container().
+			From("ubuntu:latest").
+			WithExec([]string{"apt-get", "update"}).
+			WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "unzip"}),
+	})
+
+	return m.testTerragruntVersions(ctx, targetModule, false)
+}
+
+func (m *Tests) testTerragruntVersions(ctx context.Context, targetModule *dagger.{{.module_name}}, isAlpine bool) error {
+	versions := map[string]string{
+		"0.53.7": "1.8.0",
+		"0.66.5": "1.7.0",
+		"0.63.5": "1.6.0",
+		"0.66.8": "1.9.4",
+	}
+
+	for terragruntVersion, tfVersion := range versions {
+		if err := m.verifyModule(ctx, targetModule, terragruntVersion, tfVersion, isAlpine); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Tests) verifyModule(
+	ctx context.Context,
+	targetModule *dagger.{{.module_name}},
+	terragruntVersion, tfVersion string,
+	isAlpine bool,
+) error {
+	var opts interface{}
+	if isAlpine {
+		opts = dagger.{{.module_name}}WithTerragruntAlpineOpts{
+			Version:   terragruntVersion,
+			TfVersion: tfVersion,
+		}
+
+		alpineOpts, ok := opts.(dagger.{{.module_name}}WithTerragruntAlpineOpts)
+
+		if !ok {
+			return Errorf("failed to assert type for Alpine options")
+		}
+
+		targetModule = targetModule.WithTerragruntAlpine(alpineOpts)
+	} else {
+		opts = dagger.{{.module_name}}WithTerragruntUbuntuOpts{
+			Version:   terragruntVersion,
+			TfVersion: tfVersion,
+		}
+
+		ubuntuOpts, ok := opts.(dagger.{{.module_name}}WithTerragruntUbuntuOpts)
+
+		if !ok {
+			return Errorf("failed to assert type for Ubuntu options")
+		}
+
+		targetModule = targetModule.WithTerragruntUbuntu(ubuntuOpts)
+	}
+
+	tests := []struct {
+		command []string
+		output  string
+		check   string
+	}{
+		{[]string{"terraform", "version"}, tfVersion, "Terraform version"},
+		{[]string{"which", "terraform"}, "/usr/local/bin/terraform", "Terraform path"},
+		{[]string{"terragrunt", "--version"}, terragruntVersion, "Terragrunt version"},
+		{[]string{"which", "terragrunt"}, "/usr/local/bin/terragrunt", "Terragrunt path"},
+	}
+
+	for _, test := range tests {
+		out, err := targetModule.Ctr().WithExec(test.command).Stdout(ctx)
+
+		if err != nil {
+			return WrapErrorf(err, "failed to get %s, the output was: %s", test.check, out)
+		}
+
+		if !strings.Contains(out, test.output) {
+			return Errorf("expected %s to contain %s, got %s", test.check, test.output, out)
+		}
+	}
+
+	return nil
+}

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -108,6 +108,8 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test IAC specific functions.
 	polTests.Go(m.TestIACWithTerraformUbuntu)
 	polTests.Go(m.TestIACWithTerraformAlpine)
+	polTests.Go(m.TestIACWithTerragruntUbuntu)
+	polTests.Go(m.TestIACWithTerragruntAlpine)
 	// Test Dagger specific functions.
 	polTests.Go(m.TestDaggerWithDaggerCLI)
 	polTests.Go(m.TestDaggerSetupDaggerInDagger)

--- a/.github/workflows/ci-mod-module-template.yaml
+++ b/.github/workflows/ci-mod-module-template.yaml
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.4]
+                dagversion: [0.12.5]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest

--- a/module-template/dagger.json
+++ b/module-template/dagger.json
@@ -10,5 +10,5 @@
     "examples/go"
   ],
   "source": ".",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.5"
 }

--- a/module-template/examples/go/dagger.json
+++ b/module-template/examples/go/dagger.json
@@ -14,5 +14,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.5"
 }

--- a/module-template/iac_terraform.go
+++ b/module-template/iac_terraform.go
@@ -7,8 +7,6 @@ import (
 const (
 	latestVersion       = "latest"
 	terraformReleaseURL = "https://releases.hashicorp.com/terraform"
-	hashicorpGPGURL     = "https://apt.releases.hashicorp.com/gpg"
-	hashicorpRepoURL    = "https://apt.releases.hashicorp.com"
 )
 
 // resolveTerraformVersion resolves the provided version to "latest" if it's empty.

--- a/module-template/iac_terragrunt.go
+++ b/module-template/iac_terragrunt.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
+)
+
+const (
+	terragruntLatestVersion          = "latest"
+	terragruntReleaseURL             = "https://github.com/gruntwork-io/terragrunt/releases/download"
+	terragruntDefaultVer             = "v0.66.8"
+	terraformReleaseURLForTerragrunt = "https://releases.hashicorp.com/terraform"
+	terraformDefaultVer              = "1.9.4"
+)
+
+// resolveTerragruntVersion resolves the provided version to "latest" if it's empty.
+func resolveTerragruntVersion(version string) string {
+	if version == "" || version == "latest" {
+		return getLatestTerragruntVersion()
+	}
+	return version
+}
+
+// resolveTerraformVersionInTerragrunt resolves the provided version to "latest" if it's empty.
+func resolveTerraformVersionInTerragrunt(version string) string {
+	if version == "" {
+		return terragruntLatestVersion
+	}
+	return version
+}
+
+// getLatestTerragruntVersion fetches the latest Terragrunt version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerragruntVersion() string {
+	// Placeholder: In reality, you'd fetch this from Terragrunt's releases page or API
+	return terragruntDefaultVer
+}
+
+// getLatestTerraformVersionInTerragrunt fetches the latest Terraform version.
+// This is a placeholder function. In a real scenario, you'd implement logic to fetch the latest version.
+func getLatestTerraformVersionInTerragrunt() string {
+	// Placeholder: In reality, you'd fetch this from Terraform's releases page or API
+	return terraformDefaultVer
+}
+
+// WithTerragruntUbuntu sets up the container with Terragrunt and optionally Terraform on Ubuntu.
+// It updates the package list, installs required dependencies, and then installs the specified versions of Terragrunt and Terraform.
+//
+// Parameters:
+// version - The version of Terragrunt to install. If empty, "latest" will be installed.
+// tfVersion - The version of Terraform to install. If empty, "latest" will be installed.
+// skipTerraform - If true, Terraform installation will be skipped.
+func (m *ModuleTemplate) WithTerragruntUbuntu(
+	// version is the version of Terragrunt to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+	// tfVersion is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	tfVersion string,
+	// skipTerraform if true, Terraform installation will be skipped.
+	// +optional
+	skipTerraform bool,
+) *ModuleTemplate {
+	version = resolveTerragruntVersion(version)
+	if version == terragruntLatestVersion {
+		version = getLatestTerragruntVersion()
+	}
+
+	tfVersion = resolveTerraformVersionInTerragrunt(tfVersion)
+	if tfVersion == terragruntLatestVersion {
+		tfVersion = getLatestTerraformVersionInTerragrunt()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesTerragruntUbuntu()
+	m.Ctr = m.downloadAndInstallTerragrunt(version)
+
+	if !skipTerraform {
+		m.Ctr = m.downloadAndInstallTerraformInTerragrunt(tfVersion)
+	}
+
+	return m.verifyTerragruntInstallation()
+}
+
+// WithTerragruntAlpine sets up the container with Terragrunt and optionally Terraform on Alpine Linux.
+// It updates the package list, installs required dependencies, and then installs the specified versions of Terragrunt and Terraform.
+//
+// Parameters:
+// version - The version of Terragrunt to install. If empty, "latest" will be installed.
+// tfVersion - The version of Terraform to install. If empty, "latest" will be installed.
+// skipTerraform - If true, Terraform installation will be skipped.
+func (m *ModuleTemplate) WithTerragruntAlpine(
+	// version is the version of Terragrunt to install. If empty, it will be installed as "latest".
+	// +optional
+	version string,
+	// tfVersion is the version of Terraform to install. If empty, it will be installed as "latest".
+	// +optional
+	tfVersion string,
+	// skipTerraform if true, Terraform installation will be skipped.
+	// +optional
+	skipTerraform bool,
+) *ModuleTemplate {
+	version = resolveTerragruntVersion(version)
+	if version == terragruntLatestVersion {
+		version = getLatestTerragruntVersion()
+	}
+
+	tfVersion = resolveTerraformVersionInTerragrunt(tfVersion)
+	if tfVersion == terragruntLatestVersion {
+		tfVersion = getLatestTerraformVersionInTerragrunt()
+	}
+
+	m.Ctr = m.downloadRequiredUtilitiesTerragruntAlpine()
+	m.Ctr = m.downloadAndInstallTerragrunt(version)
+
+	if !skipTerraform {
+		m.Ctr = m.downloadAndInstallTerraformInTerragrunt(tfVersion)
+	}
+
+	return m.verifyTerragruntInstallation()
+}
+
+func (m *ModuleTemplate) downloadAndInstallTerragrunt(version string) *dagger.Container {
+	// Remove "v" prefix if present
+	version = strings.TrimPrefix(version, "v")
+	terragruntURL := fmt.Sprintf("%s/v%s/terragrunt_linux_amd64", terragruntReleaseURL, version)
+	return m.Ctr.
+		WithExec([]string{"wget", "-q", "-O", "/usr/local/bin/terragrunt", terragruntURL}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/terragrunt"})
+}
+
+func (m *ModuleTemplate) downloadAndInstallTerraformInTerragrunt(version string) *dagger.Container {
+	terraformURL := fmt.Sprintf("%s/%s/terraform_%s_linux_amd64.zip", terraformReleaseURLForTerragrunt, version, version)
+	return m.Ctr.
+		WithExec([]string{"wget", "-q", terraformURL}).
+		WithExec([]string{"unzip", fmt.Sprintf("terraform_%s_linux_amd64.zip", version)}).
+		WithExec([]string{"mv", "terraform", "/usr/local/bin/"}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/terraform"}).
+		WithExec([]string{"rm", fmt.Sprintf("terraform_%s_linux_amd64.zip", version)})
+}
+
+func (m *ModuleTemplate) verifyTerragruntInstallation() *ModuleTemplate {
+	m.Ctr = m.Ctr.
+		WithExec([]string{"terragrunt", "--version"}).
+		WithExec([]string{"terraform", "version"})
+	return m
+}
+
+func (m *ModuleTemplate) downloadRequiredUtilitiesTerragruntAlpine() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apk", "update"}).
+		WithExec([]string{"apk", "add", "--no-cache", "curl", "wget", "unzip"})
+}
+
+func (m *ModuleTemplate) downloadRequiredUtilitiesTerragruntUbuntu() *dagger.Container {
+	return m.Ctr.
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "unzip"})
+}

--- a/module-template/iac_terragrunt.go
+++ b/module-template/iac_terragrunt.go
@@ -17,9 +17,10 @@ const (
 
 // resolveTerragruntVersion resolves the provided version to "latest" if it's empty.
 func resolveTerragruntVersion(version string) string {
-	if version == "" || version == "latest" {
+	if version == "" || version == terragruntLatestVersion {
 		return getLatestTerragruntVersion()
 	}
+
 	return version
 }
 
@@ -28,6 +29,7 @@ func resolveTerraformVersionInTerragrunt(version string) string {
 	if version == "" {
 		return terragruntLatestVersion
 	}
+
 	return version
 }
 
@@ -46,7 +48,8 @@ func getLatestTerraformVersionInTerragrunt() string {
 }
 
 // WithTerragruntUbuntu sets up the container with Terragrunt and optionally Terraform on Ubuntu.
-// It updates the package list, installs required dependencies, and then installs the specified versions of Terragrunt and Terraform.
+// It updates the package list, installs required dependencies, and then installs
+// the specified versions of Terragrunt and Terraform.
 //
 // Parameters:
 // version - The version of Terragrunt to install. If empty, "latest" will be installed.
@@ -84,7 +87,8 @@ func (m *ModuleTemplate) WithTerragruntUbuntu(
 }
 
 // WithTerragruntAlpine sets up the container with Terragrunt and optionally Terraform on Alpine Linux.
-// It updates the package list, installs required dependencies, and then installs the specified versions of Terragrunt and Terraform.
+// It updates the package list, installs required dependencies, and then installs
+// the specified versions of Terragrunt and Terraform.
 //
 // Parameters:
 // version - The version of Terragrunt to install. If empty, "latest" will be installed.
@@ -125,6 +129,7 @@ func (m *ModuleTemplate) downloadAndInstallTerragrunt(version string) *dagger.Co
 	// Remove "v" prefix if present
 	version = strings.TrimPrefix(version, "v")
 	terragruntURL := fmt.Sprintf("%s/v%s/terragrunt_linux_amd64", terragruntReleaseURL, version)
+
 	return m.Ctr.
 		WithExec([]string{"wget", "-q", "-O", "/usr/local/bin/terragrunt", terragruntURL}).
 		WithExec([]string{"chmod", "+x", "/usr/local/bin/terragrunt"})
@@ -132,6 +137,7 @@ func (m *ModuleTemplate) downloadAndInstallTerragrunt(version string) *dagger.Co
 
 func (m *ModuleTemplate) downloadAndInstallTerraformInTerragrunt(version string) *dagger.Container {
 	terraformURL := fmt.Sprintf("%s/%s/terraform_%s_linux_amd64.zip", terraformReleaseURLForTerragrunt, version, version)
+
 	return m.Ctr.
 		WithExec([]string{"wget", "-q", terraformURL}).
 		WithExec([]string{"unzip", fmt.Sprintf("terraform_%s_linux_amd64.zip", version)}).
@@ -144,6 +150,7 @@ func (m *ModuleTemplate) verifyTerragruntInstallation() *ModuleTemplate {
 	m.Ctr = m.Ctr.
 		WithExec([]string{"terragrunt", "--version"}).
 		WithExec([]string{"terraform", "version"})
+
 	return m
 }
 

--- a/module-template/tests/iac_terragrunt.go
+++ b/module-template/tests/iac_terragrunt.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
+)
+
+func (m *Tests) TestIACWithTerragruntAlpine(ctx context.Context) error {
+	targetModule := dag.ModuleTemplate(dagger.ModuleTemplateOpts{
+		Ctr: dag.
+			Container().
+			From("alpine:latest").
+			WithExec([]string{"apk", "add", "curl"}),
+	})
+
+	return m.testTerragruntVersions(ctx, targetModule, true)
+}
+
+func (m *Tests) TestIACWithTerragruntUbuntu(ctx context.Context) error {
+	targetModule := dag.ModuleTemplate(dagger.ModuleTemplateOpts{
+		Ctr: dag.
+			Container().
+			From("ubuntu:latest").
+			WithExec([]string{"apt-get", "update"}).
+			WithExec([]string{"apt-get", "install", "-y", "curl", "wget", "unzip"}),
+	})
+
+	return m.testTerragruntVersions(ctx, targetModule, false)
+}
+
+func (m *Tests) testTerragruntVersions(ctx context.Context, targetModule *dagger.ModuleTemplate, isAlpine bool) error {
+	versions := map[string]string{
+		"0.53.7": "1.8.0",
+		"0.66.5": "1.7.0",
+		"0.63.5": "1.6.0",
+		"0.66.8": "1.9.4",
+	}
+
+	for terragruntVersion, tfVersion := range versions {
+		if err := m.verifyModule(ctx, targetModule, terragruntVersion, tfVersion, isAlpine); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Tests) verifyModule(ctx context.Context, targetModule *dagger.ModuleTemplate, terragruntVersion, tfVersion string, isAlpine bool) error {
+	var opts interface{}
+	if isAlpine {
+		opts = dagger.ModuleTemplateWithTerragruntAlpineOpts{
+			Version:   terragruntVersion,
+			TfVersion: tfVersion,
+		}
+		targetModule = targetModule.WithTerragruntAlpine(opts.(dagger.ModuleTemplateWithTerragruntAlpineOpts))
+	} else {
+		opts = dagger.ModuleTemplateWithTerragruntUbuntuOpts{
+			Version:   terragruntVersion,
+			TfVersion: tfVersion,
+		}
+		targetModule = targetModule.WithTerragruntUbuntu(opts.(dagger.ModuleTemplateWithTerragruntUbuntuOpts))
+	}
+
+	tests := []struct {
+		command []string
+		output  string
+		check   string
+	}{
+		{[]string{"terraform", "version"}, tfVersion, "Terraform version"},
+		{[]string{"which", "terraform"}, "/usr/local/bin/terraform", "Terraform path"},
+		{[]string{"terragrunt", "--version"}, terragruntVersion, "Terragrunt version"},
+		{[]string{"which", "terragrunt"}, "/usr/local/bin/terragrunt", "Terragrunt path"},
+	}
+
+	for _, test := range tests {
+		out, err := targetModule.Ctr().WithExec(test.command).Stdout(ctx)
+		if err != nil {
+			return WrapErrorf(err, "failed to get %s, the output was: %s", test.check, out)
+		}
+		if !strings.Contains(out, test.output) {
+			return Errorf("expected %s to contain %s, got %s", test.check, test.output, out)
+		}
+	}
+
+	return nil
+}

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -108,6 +108,8 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test IAC specific functions.
 	polTests.Go(m.TestIACWithTerraformUbuntu)
 	polTests.Go(m.TestIACWithTerraformAlpine)
+	polTests.Go(m.TestIACWithTerragruntUbuntu)
+	polTests.Go(m.TestIACWithTerragruntAlpine)
 	// Test Dagger specific functions.
 	polTests.Go(m.TestDaggerWithDaggerCLI)
 	polTests.Go(m.TestDaggerSetupDaggerInDagger)


### PR DESCRIPTION
This commit adds support for Terragrunt, a tool for managing Terraform configurations, to the module template. The changes include:

- Add `iac_terragrunt.go` file to handle Terragrunt-specific functionality.
- Implement `WithTerragruntUbuntu` and `WithTerragruntAlpine` methods to set up the container with Terragrunt (and optionally Terraform) on Ubuntu and Alpine Linux, respectively.
- Add helper functions to resolve Terragrunt and Terraform versions, and fetch the latest versions of each.
- Remove the `hashicorpGPGURL` and `hashicorpRepoURL` constants from `iac_terraform.go` as they are not needed for the Terragrunt-specific functionality.

The main purpose of these changes is to provide a more comprehensive infrastructure as code (IaC) experience by integrating Terragrunt into the module template, allowing users to manage their Terraform configurations more effectively.