### PR TITLE
feat: Add Dagger 0.12.5 to CI workflow

### DIFF
--- a/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
+++ b/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
         name: Lint {{.module_name_pkg}} on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
         steps:
@@ -159,7 +159,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
         needs: [dagger-linter, golangci-lint]
         name: Run Tests 🧪 in {{.module_name_pkg}} on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.4]
+                dagversion: [0.12.4, 0.12.5]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest


### PR DESCRIPTION
The commit message is as follows:

feat: Add Dagger 0.12.5 to CI workflow

This change adds Dagger version 0.12.5 to the CI workflow matrix for the following jobs:
- Lint {{.module_name_pkg}}
- Run recipes 🥗 in {{.module_name_pkg}}/examples/go
- Run Tests 🧪 in {{.module_name_pkg}}

This will ensure that the project is tested against the latest version of Dagger to catch any potential issues or incompatibilities.