### PR TITLE
feat: Add base image configuration for ModuleTemplate

### DIFF
--- a/.daggerx/templates/module/container.go.tmpl
+++ b/.daggerx/templates/module/container.go.tmpl
@@ -1,0 +1,70 @@
+package main
+
+import "fmt"
+
+const (
+	defaultAlpineImage        = "alpine"
+	defaultUbuntuImage        = "ubuntu"
+	defaultBusyBoxImage       = "busybox"
+	defaultImageVersionLatest = "latest"
+)
+
+// BaseAlpine sets the base image to an Alpine Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Alpine image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the {{.module_name}} instance.
+func (m *{{.module_name}}) BaseAlpine(
+	// version is the version of the Alpine image to use, e.g., "3.17.3".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	if version == "" {
+		version = defaultImageVersionLatest
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultAlpineImage, version)
+
+	return m.Base(imageURL)
+}
+
+// BaseUbuntu sets the base image to an Ubuntu Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Ubuntu image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the {{.module_name}} instance.
+func (m *{{.module_name}}) BaseUbuntu(
+	// version is the version of the Ubuntu image to use, e.g., "22.04".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	if version == "" {
+		version = defaultImageVersionLatest
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultUbuntuImage, version)
+
+	return m.Base(imageURL)
+}
+
+// BaseBusyBox sets the base image to a BusyBox Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the BusyBox image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the {{.module_name}} instance.
+func (m *{{.module_name}}) BaseBusyBox(
+	// version is the version of the BusyBox image to use, e.g., "1.35.0".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	if version == "" {
+		version = defaultImageVersionLatest
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
+
+	return m.Base(imageURL)
+}

--- a/.daggerx/templates/module/main.go.tmpl
+++ b/.daggerx/templates/module/main.go.tmpl
@@ -11,8 +11,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/internal/dagger"
 
 	"github.com/Excoriate/daggerx/pkg/containerx"
@@ -65,7 +63,7 @@ func New(
 		})
 
 		if err != nil {
-			return nil, WrapError(err, "failed to get image URL")
+			return nil, WrapErrorf(err, "failed to get container image URl %s", imageURL)
 		}
 
 		dagModule.Base(imageURL)
@@ -98,70 +96,4 @@ func (m *{{.module_name}}) Base(imageURL string) *{{.module_name}} {
 	m.Ctr = c
 
 	return m
-}
-
-const (
-	defaultAlpineImage  = "alpine"
-	defaultUbuntuImage  = "ubuntu"
-	defaultBusyBoxImage = "busybox"
-)
-
-// BaseAlpine sets the base image to an Alpine Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the Alpine image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the {{.module_name}} instance.
-func (m *{{.module_name}}) BaseAlpine(
-	// version is the version of the Alpine image to use, e.g., "3.17.3".
-	// +optional
-	version string,
-) *{{.module_name}} {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultAlpineImage, version)
-
-	return m.Base(imageURL)
-}
-
-// BaseUbuntu sets the base image to an Ubuntu Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the Ubuntu image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the {{.module_name}} instance.
-func (m *{{.module_name}}) BaseUbuntu(
-	// version is the version of the Ubuntu image to use, e.g., "22.04".
-	// +optional
-	version string,
-) *{{.module_name}} {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultUbuntuImage, version)
-
-	return m.Base(imageURL)
-}
-
-// BaseBusyBox sets the base image to a BusyBox Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the BusyBox image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the {{.module_name}} instance.
-func (m *{{.module_name}}) BaseBusyBox(
-	// version is the version of the BusyBox image to use, e.g., "1.35.0".
-	// +optional
-	version string,
-) *{{.module_name}} {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
-
-	return m.Base(imageURL)
 }

--- a/.daggerx/templates/tests/apis.go.tmpl
+++ b/.daggerx/templates/tests/apis.go.tmpl
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
 	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
 )
 
 // TestWithContainer tests if the container is set correctly.
@@ -65,93 +66,6 @@ func (m *Tests) TestTerminal() *dagger.Container {
 	return targetModule.
 		Ctr().
 		Terminal()
-}
-
-// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
-//
-// This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
-// It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
-func (m *Tests) TestUbuntuBase(ctx context.Context) error {
-	targetModule := dag.
-		{{.module_name}}().
-		BaseUbuntu(dagger.{{.module_name}}BaseUbuntuOpts{Version: "22.04"})
-
-	out, err := targetModule.Ctr().
-		WithExec([]string{"grep", "^ID=ubuntu$", "/etc/os-release"}).
-		Stdout(ctx)
-
-	if err != nil {
-		return WrapError(err, "failed to get Ubuntu image")
-	}
-
-	if !strings.Contains(out, "ID=ubuntu") {
-		return WrapErrorf(err, "expected Ubuntu 22.04 or ID=ubuntu, got %s", out)
-	}
-
-	return nil
-}
-
-// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
-//
-// This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
-// It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
-func (m *Tests) TestAlpineBase(ctx context.Context) error {
-	targetModule := dag.{{.module_name}}().
-		BaseAlpine(dagger.{{.module_name}}BaseAlpineOpts{Version: "3.17.3"})
-
-	out, err := targetModule.Ctr().WithExec([]string{"cat", "/etc/os-release"}).Stdout(ctx)
-	if err != nil {
-		return WrapError(err, "failed to get Alpine image")
-	}
-
-	// Adjust the conditions to match the actual output.
-	if !strings.Contains(out, "Alpine Linux") || !strings.Contains(out, "VERSION_ID=3.17.3") {
-		return WrapErrorf(err, "expected Alpine Linux VERSION_ID=3.17.3, got %s", out)
-	}
-
-	return nil
-}
-
-// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
-//
-// This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
-// It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
-func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
-	targetModule := dag.
-		{{.module_name}}().
-		BaseBusyBox(dagger.{{.module_name}}BaseBusyBoxOpts{Version: "1.35.0"})
-
-	out, err := targetModule.Ctr().
-		WithExec([]string{"busybox", "--help"}).
-		Stdout(ctx)
-
-	if err != nil {
-		return WrapError(err, "failed to get BusyBox image")
-	}
-
-	if !strings.Contains(out, "v1.35.0") {
-		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
-	}
-
-	return nil
 }
 
 // TestPassingEnvVarsInConstructor tests if the environment variables are passed correctly in the constructor.

--- a/.daggerx/templates/tests/container.go.tmpl
+++ b/.daggerx/templates/tests/container.go.tmpl
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+)
+
+// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
+//
+// This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
+// It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
+func (m *Tests) TestUbuntuBase(ctx context.Context) error {
+	targetModule := dag.
+		{{.module_name}}().
+		BaseUbuntu(dagger.{{.module_name}}BaseUbuntuOpts{Version: "22.04"})
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"grep", "^ID=ubuntu$", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get Ubuntu image")
+	}
+
+	if !strings.Contains(out, "ID=ubuntu") {
+		return WrapErrorf(err, "expected Ubuntu 22.04 or ID=ubuntu, got %s", out)
+	}
+
+	return nil
+}
+
+// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
+//
+// This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
+// It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
+func (m *Tests) TestAlpineBase(ctx context.Context) error {
+	targetModule := dag.{{.module_name}}().
+		BaseAlpine(dagger.{{.module_name}}BaseAlpineOpts{Version: "3.17.3"})
+
+	out, err := targetModule.Ctr().WithExec([]string{"cat", "/etc/os-release"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to get Alpine image")
+	}
+
+	// Adjust the conditions to match the actual output.
+	if !strings.Contains(out, "Alpine Linux") || !strings.Contains(out, "VERSION_ID=3.17.3") {
+		return WrapErrorf(err, "expected Alpine Linux VERSION_ID=3.17.3, got %s", out)
+	}
+
+	return nil
+}
+
+// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
+//
+// This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
+// It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
+func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
+	targetModule := dag.
+		{{.module_name}}().
+		BaseBusyBox(dagger.{{.module_name}}BaseBusyBoxOpts{Version: "1.35.0"})
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"busybox", "--help"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get BusyBox image")
+	}
+
+	if !strings.Contains(out, "v1.35.0") {
+		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
+	}
+
+	return nil
+}

--- a/module-template/container.go
+++ b/module-template/container.go
@@ -1,0 +1,69 @@
+package main
+
+import "fmt"
+
+const (
+	defaultAlpineImage  = "alpine"
+	defaultUbuntuImage  = "ubuntu"
+	defaultBusyBoxImage = "busybox"
+)
+
+// BaseAlpine sets the base image to an Alpine Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Alpine image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the ModuleTemplate instance.
+func (m *ModuleTemplate) BaseAlpine(
+	// version is the version of the Alpine image to use, e.g., "3.17.3".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	if version == "" {
+		version = "latest"
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultAlpineImage, version)
+
+	return m.Base(imageURL)
+}
+
+// BaseUbuntu sets the base image to an Ubuntu Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Ubuntu image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the ModuleTemplate instance.
+func (m *ModuleTemplate) BaseUbuntu(
+	// version is the version of the Ubuntu image to use, e.g., "22.04".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	if version == "" {
+		version = "latest"
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultUbuntuImage, version)
+
+	return m.Base(imageURL)
+}
+
+// BaseBusyBox sets the base image to a BusyBox Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the BusyBox image to use. Optional parameter. Defaults to "latest".
+//
+// Returns a pointer to the ModuleTemplate instance.
+func (m *ModuleTemplate) BaseBusyBox(
+	// version is the version of the BusyBox image to use, e.g., "1.35.0".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	if version == "" {
+		version = "latest"
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
+
+	return m.Base(imageURL)
+}

--- a/module-template/container.go
+++ b/module-template/container.go
@@ -3,9 +3,10 @@ package main
 import "fmt"
 
 const (
-	defaultAlpineImage  = "alpine"
-	defaultUbuntuImage  = "ubuntu"
-	defaultBusyBoxImage = "busybox"
+	defaultAlpineImage        = "alpine"
+	defaultUbuntuImage        = "ubuntu"
+	defaultBusyBoxImage       = "busybox"
+	defaultImageVersionLatest = "latest"
 )
 
 // BaseAlpine sets the base image to an Alpine Linux image and creates the base container.
@@ -20,7 +21,7 @@ func (m *ModuleTemplate) BaseAlpine(
 	version string,
 ) *ModuleTemplate {
 	if version == "" {
-		version = "latest"
+		version = defaultImageVersionLatest
 	}
 
 	imageURL := fmt.Sprintf("%s:%s", defaultAlpineImage, version)
@@ -40,7 +41,7 @@ func (m *ModuleTemplate) BaseUbuntu(
 	version string,
 ) *ModuleTemplate {
 	if version == "" {
-		version = "latest"
+		version = defaultImageVersionLatest
 	}
 
 	imageURL := fmt.Sprintf("%s:%s", defaultUbuntuImage, version)
@@ -60,7 +61,7 @@ func (m *ModuleTemplate) BaseBusyBox(
 	version string,
 ) *ModuleTemplate {
 	if version == "" {
-		version = "latest"
+		version = defaultImageVersionLatest
 	}
 
 	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)

--- a/module-template/main.go
+++ b/module-template/main.go
@@ -63,7 +63,7 @@ func New(
 		})
 
 		if err != nil {
-			return nil, WrapError(err, "failed to get image URL")
+			return nil, WrapErrorf(err, "failed to get container image URl %s", imageURL)
 		}
 
 		dagModule.Base(imageURL)

--- a/module-template/main.go
+++ b/module-template/main.go
@@ -11,8 +11,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
 
 	"github.com/Excoriate/daggerx/pkg/containerx"
@@ -98,70 +96,4 @@ func (m *ModuleTemplate) Base(imageURL string) *ModuleTemplate {
 	m.Ctr = c
 
 	return m
-}
-
-const (
-	defaultAlpineImage  = "alpine"
-	defaultUbuntuImage  = "ubuntu"
-	defaultBusyBoxImage = "busybox"
-)
-
-// BaseAlpine sets the base image to an Alpine Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the Alpine image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the ModuleTemplate instance.
-func (m *ModuleTemplate) BaseAlpine(
-	// version is the version of the Alpine image to use, e.g., "3.17.3".
-	// +optional
-	version string,
-) *ModuleTemplate {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultAlpineImage, version)
-
-	return m.Base(imageURL)
-}
-
-// BaseUbuntu sets the base image to an Ubuntu Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the Ubuntu image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the ModuleTemplate instance.
-func (m *ModuleTemplate) BaseUbuntu(
-	// version is the version of the Ubuntu image to use, e.g., "22.04".
-	// +optional
-	version string,
-) *ModuleTemplate {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultUbuntuImage, version)
-
-	return m.Base(imageURL)
-}
-
-// BaseBusyBox sets the base image to a BusyBox Linux image and creates the base container.
-//
-// Parameters:
-// - version: The version of the BusyBox image to use. Optional parameter. Defaults to "latest".
-//
-// Returns a pointer to the ModuleTemplate instance.
-func (m *ModuleTemplate) BaseBusyBox(
-	// version is the version of the BusyBox image to use, e.g., "1.35.0".
-	// +optional
-	version string,
-) *ModuleTemplate {
-	if version == "" {
-		version = "latest"
-	}
-
-	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
-
-	return m.Base(imageURL)
 }

--- a/module-template/tests/apis.go
+++ b/module-template/tests/apis.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
 	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
 )
 
 // TestWithContainer tests if the container is set correctly.
@@ -65,93 +66,6 @@ func (m *Tests) TestTerminal() *dagger.Container {
 	return targetModule.
 		Ctr().
 		Terminal()
-}
-
-// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
-//
-// This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
-// It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
-func (m *Tests) TestUbuntuBase(ctx context.Context) error {
-	targetModule := dag.
-		ModuleTemplate().
-		BaseUbuntu(dagger.ModuleTemplateBaseUbuntuOpts{Version: "22.04"})
-
-	out, err := targetModule.Ctr().
-		WithExec([]string{"grep", "^ID=ubuntu$", "/etc/os-release"}).
-		Stdout(ctx)
-
-	if err != nil {
-		return WrapError(err, "failed to get Ubuntu image")
-	}
-
-	if !strings.Contains(out, "ID=ubuntu") {
-		return WrapErrorf(err, "expected Ubuntu 22.04 or ID=ubuntu, got %s", out)
-	}
-
-	return nil
-}
-
-// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
-//
-// This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
-// It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
-func (m *Tests) TestAlpineBase(ctx context.Context) error {
-	targetModule := dag.ModuleTemplate().
-		BaseAlpine(dagger.ModuleTemplateBaseAlpineOpts{Version: "3.17.3"})
-
-	out, err := targetModule.Ctr().WithExec([]string{"cat", "/etc/os-release"}).Stdout(ctx)
-	if err != nil {
-		return WrapError(err, "failed to get Alpine image")
-	}
-
-	// Adjust the conditions to match the actual output.
-	if !strings.Contains(out, "Alpine Linux") || !strings.Contains(out, "VERSION_ID=3.17.3") {
-		return WrapErrorf(err, "expected Alpine Linux VERSION_ID=3.17.3, got %s", out)
-	}
-
-	return nil
-}
-
-// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
-//
-// This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
-// It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
-//
-// Arguments:
-// - ctx (context.Context): The context for the test execution.
-//
-// Returns:
-//   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
-func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
-	targetModule := dag.
-		ModuleTemplate().
-		BaseBusyBox(dagger.ModuleTemplateBaseBusyBoxOpts{Version: "1.35.0"})
-
-	out, err := targetModule.Ctr().
-		WithExec([]string{"busybox", "--help"}).
-		Stdout(ctx)
-
-	if err != nil {
-		return WrapError(err, "failed to get BusyBox image")
-	}
-
-	if !strings.Contains(out, "v1.35.0") {
-		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
-	}
-
-	return nil
 }
 
 // TestPassingEnvVarsInConstructor tests if the environment variables are passed correctly in the constructor.

--- a/module-template/tests/container.go
+++ b/module-template/tests/container.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
+)
+
+// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
+//
+// This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
+// It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
+func (m *Tests) TestUbuntuBase(ctx context.Context) error {
+	targetModule := dag.
+		ModuleTemplate().
+		BaseUbuntu(dagger.ModuleTemplateBaseUbuntuOpts{Version: "22.04"})
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"grep", "^ID=ubuntu$", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get Ubuntu image")
+	}
+
+	if !strings.Contains(out, "ID=ubuntu") {
+		return WrapErrorf(err, "expected Ubuntu 22.04 or ID=ubuntu, got %s", out)
+	}
+
+	return nil
+}
+
+// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
+//
+// This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
+// It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
+func (m *Tests) TestAlpineBase(ctx context.Context) error {
+	targetModule := dag.ModuleTemplate().
+		BaseAlpine(dagger.ModuleTemplateBaseAlpineOpts{Version: "3.17.3"})
+
+	out, err := targetModule.Ctr().WithExec([]string{"cat", "/etc/os-release"}).Stdout(ctx)
+	if err != nil {
+		return WrapError(err, "failed to get Alpine image")
+	}
+
+	// Adjust the conditions to match the actual output.
+	if !strings.Contains(out, "Alpine Linux") || !strings.Contains(out, "VERSION_ID=3.17.3") {
+		return WrapErrorf(err, "expected Alpine Linux VERSION_ID=3.17.3, got %s", out)
+	}
+
+	return nil
+}
+
+// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
+//
+// This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
+// It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
+func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
+	targetModule := dag.
+		ModuleTemplate().
+		BaseBusyBox(dagger.ModuleTemplateBaseBusyBoxOpts{Version: "1.35.0"})
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"busybox", "--help"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get BusyBox image")
+	}
+
+	if !strings.Contains(out, "v1.35.0") {
+		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit introduces three new methods to the `ModuleTemplate` struct:

1. `BaseAlpine`: Sets the base image to an Alpine Linux image and creates the base container. The version of the Alpine image can be specified, and it defaults to "latest" if not provided.

2. `BaseUbuntu`: Sets the base image to an Ubuntu Linux image and creates the base container. The version of the Ubuntu image can be specified, and it defaults to "latest" if not provided.

3. `BaseBusyBox`: Sets the base image to a BusyBox Linux image and creates the base container. The version of the BusyBox image can be specified, and it defaults to "latest" if not provided.

These methods provide a convenient way to set the base image for the `ModuleTemplate` and ensure that the container is created with the desired base image. This change adds flexibility and allows users to choose the base image that best suits their needs.