### PR TITLE
feat: Add support for GoReleaser and GoLangCILint in module-template and codegen

### DIFF
--- a/.daggerx/templates/module/golang.go.tmpl
+++ b/.daggerx/templates/module/golang.go.tmpl
@@ -523,3 +523,52 @@ func (m *{{.module_name}}) WithGoTestSum(
 
 	return m.WithGoInstall(pkgs)
 }
+
+// WithGoReleaser installs the GoReleaser tool in the container environment.
+//
+// This method installs `goreleaser` using the specified version. Check
+// https://goreleaser.com/install/
+//
+// Parameters:
+// - version (string): The version of GoReleaser to use, e.g., "v2@latest".
+//
+// Example:
+//
+//	m := &{{.module_name}}{}
+//	m.WithGoReleaser("v2.2.0")  // Install GoReleaser version 2.2.0
+//
+// Returns:
+// - *{{.module_name}}: A pointer to the updated {{.module_name}} instance.
+func (m *{{.module_name}}) WithGoReleaser(
+	// version is the version of GoReleaser to use, e.g., By default, it's set "v2@latest".
+	// +optional
+	version string,
+) *{{.module_name}} {
+	if version == "" {
+		version = "v2@latest"
+	}
+
+	return m.
+		WithGoInstall([]string{"github.com/goreleaser/goreleaser/" + version})
+}
+
+// WithGoLint installs the GoLint tool in the container environment.
+//
+// This method installs `golangci-lint` using the specified version.
+//
+// Parameters:
+// - version (string): The version of GoLint to use, e.g., "v1.60.1".
+//
+// Example:
+//
+//	m := &{{.module_name}}{}
+//	m.WithGoLint("v1.60.1")  // Install GoLint version 1.60.1
+//
+// Returns:
+// - *{{.module_name}}: A pointer to the updated {{.module_name}} instance.
+func (m *{{.module_name}}) WithGoLint(
+	// version is the version of GoLint to use, e.g., "v1.60.1".
+	version string,
+) *{{.module_name}} {
+	return m.WithGoInstall([]string{"github.com/golangci/golangci-lint/cmd/golangci-lint@" + version})
+}

--- a/.daggerx/templates/tests/golang.go.tmpl
+++ b/.daggerx/templates/tests/golang.go.tmpl
@@ -740,3 +740,79 @@ func extractVersion(output string) string {
 
 	return ""
 }
+
+// TestGoWithGoReleaserAndGolangCILint tests the installation and setup
+// of GoReleaser and GoLangCILint using gotoolbox.
+//
+// This function sets up the Go toolbox with a specified Go version, installs
+// GoReleaser and GoLangCILint, and verifies their installation.
+//
+// ctx: The context for the test execution, to control cancellation and deadlines.
+//
+// Returns an error if the installation or verification of GoReleaser or GoLangCILint fails.
+func (m *Tests) TestGoWithGoReleaserAndGolangCILint(ctx context.Context) error {
+	goContainerWithGit := dag.
+		Container().
+		From("golang:1.23-alpine").
+		WithExec([]string{"apk", "add", "--no-cache", "git"})
+
+	// Initialize the Go toolbox with the specified version.
+	targetModDefault := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: goContainerWithGit,
+		})
+
+	// Set the installation commands for GoReleaser and GoLangCILint.
+	targetModDefault = targetModDefault.
+		WithGoReleaser().
+		WithGoLint("v1.60.1")
+
+	// Execute the container to install the tools.
+	_, ctrErr := targetModDefault.
+		Ctr().
+		Stdout(ctx)
+
+	if ctrErr != nil {
+		return WrapError(ctrErr, "failed to install GoReleaser and GoLangCILint")
+	}
+
+	// Check golangci-lint binary installed in path.
+	golangciPathOut, golangciPathErr := targetModDefault.
+		Ctr().
+		WithExec([]string{"which", "golangci-lint"}).
+		Stdout(ctx)
+
+	if golangciPathErr != nil {
+		return WrapError(golangciPathErr, "failed to get golangci-lint path")
+	}
+
+	if golangciPathOut == "" {
+		return Errorf("expected to have golangci-lint in path /go/bin/golangci-lint, got empty output")
+	}
+
+	if !strings.Contains(golangciPathOut, "/go/bin/golangci-lint") {
+		return Errorf("expected to have golangci-lint "+
+			"in path /go/bin/golangci-lint, got %s", golangciPathOut)
+	}
+
+	// Check goreleaser binary installed in path.
+	goreleaserPathOut, goreleaserPathErr := targetModDefault.
+		Ctr().
+		WithExec([]string{"which", "goreleaser"}).
+		Stdout(ctx)
+
+	if goreleaserPathErr != nil {
+		return WrapError(goreleaserPathErr, "failed to get goreleaser path")
+	}
+
+	if goreleaserPathOut == "" {
+		return Errorf("expected to have goreleaser in path /go/bin/goreleaser, got empty output")
+	}
+
+	if !strings.Contains(goreleaserPathOut, "/go/bin/goreleaser") {
+		return Errorf("expected to have goreleaser "+
+			"in path /go/bin/goreleaser, got %s", goreleaserPathOut)
+	}
+
+	return nil
+}

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -99,6 +99,7 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestGoWithGoPrivate)
 	polTests.Go(m.TestGoWithGCCCompiler)
 	polTests.Go(m.TestGoWithGoTestSum)
+	polTests.Go(m.TestGoWithGoReleaserAndGolangCILint)
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)

--- a/module-template/golang.go
+++ b/module-template/golang.go
@@ -523,3 +523,52 @@ func (m *ModuleTemplate) WithGoTestSum(
 
 	return m.WithGoInstall(pkgs)
 }
+
+// WithGoReleaser installs the GoReleaser tool in the container environment.
+//
+// This method installs `goreleaser` using the specified version. Check
+// https://goreleaser.com/install/
+//
+// Parameters:
+// - version (string): The version of GoReleaser to use, e.g., "v2@latest".
+//
+// Example:
+//
+//	m := &ModuleTemplate{}
+//	m.WithGoReleaser("v2.2.0")  // Install GoReleaser version 2.2.0
+//
+// Returns:
+// - *ModuleTemplate: A pointer to the updated ModuleTemplate instance.
+func (m *ModuleTemplate) WithGoReleaser(
+	// version is the version of GoReleaser to use, e.g., By default, it's set "v2@latest".
+	// +optional
+	version string,
+) *ModuleTemplate {
+	if version == "" {
+		version = "v2@latest"
+	}
+
+	return m.
+		WithGoInstall([]string{"github.com/goreleaser/goreleaser/" + version})
+}
+
+// WithGoLint installs the GoLint tool in the container environment.
+//
+// This method installs `golangci-lint` using the specified version.
+//
+// Parameters:
+// - version (string): The version of GoLint to use, e.g., "v1.60.1".
+//
+// Example:
+//
+//	m := &ModuleTemplate{}
+//	m.WithGoLint("v1.60.1")  // Install GoLint version 1.60.1
+//
+// Returns:
+// - *ModuleTemplate: A pointer to the updated ModuleTemplate instance.
+func (m *ModuleTemplate) WithGoLint(
+	// version is the version of GoLint to use, e.g., "v1.60.1".
+	version string,
+) *ModuleTemplate {
+	return m.WithGoInstall([]string{"github.com/golangci/golangci-lint/cmd/golangci-lint@" + version})
+}

--- a/module-template/tests/golang.go
+++ b/module-template/tests/golang.go
@@ -740,3 +740,79 @@ func extractVersion(output string) string {
 
 	return ""
 }
+
+// TestGoWithGoReleaserAndGolangCILint tests the installation and setup
+// of GoReleaser and GoLangCILint using gotoolbox.
+//
+// This function sets up the Go toolbox with a specified Go version, installs
+// GoReleaser and GoLangCILint, and verifies their installation.
+//
+// ctx: The context for the test execution, to control cancellation and deadlines.
+//
+// Returns an error if the installation or verification of GoReleaser or GoLangCILint fails.
+func (m *Tests) TestGoWithGoReleaserAndGolangCILint(ctx context.Context) error {
+	goContainerWithGit := dag.
+		Container().
+		From("golang:1.23-alpine").
+		WithExec([]string{"apk", "add", "--no-cache", "git"})
+
+	// Initialize the Go toolbox with the specified version.
+	targetModDefault := dag.
+		ModuleTemplate(dagger.ModuleTemplateOpts{
+			Ctr: goContainerWithGit,
+		})
+
+	// Set the installation commands for GoReleaser and GoLangCILint.
+	targetModDefault = targetModDefault.
+		WithGoReleaser().
+		WithGoLint("v1.60.1")
+
+	// Execute the container to install the tools.
+	_, ctrErr := targetModDefault.
+		Ctr().
+		Stdout(ctx)
+
+	if ctrErr != nil {
+		return WrapError(ctrErr, "failed to install GoReleaser and GoLangCILint")
+	}
+
+	// Check golangci-lint binary installed in path.
+	golangciPathOut, golangciPathErr := targetModDefault.
+		Ctr().
+		WithExec([]string{"which", "golangci-lint"}).
+		Stdout(ctx)
+
+	if golangciPathErr != nil {
+		return WrapError(golangciPathErr, "failed to get golangci-lint path")
+	}
+
+	if golangciPathOut == "" {
+		return Errorf("expected to have golangci-lint in path /go/bin/golangci-lint, got empty output")
+	}
+
+	if !strings.Contains(golangciPathOut, "/go/bin/golangci-lint") {
+		return Errorf("expected to have golangci-lint "+
+			"in path /go/bin/golangci-lint, got %s", golangciPathOut)
+	}
+
+	// Check goreleaser binary installed in path.
+	goreleaserPathOut, goreleaserPathErr := targetModDefault.
+		Ctr().
+		WithExec([]string{"which", "goreleaser"}).
+		Stdout(ctx)
+
+	if goreleaserPathErr != nil {
+		return WrapError(goreleaserPathErr, "failed to get goreleaser path")
+	}
+
+	if goreleaserPathOut == "" {
+		return Errorf("expected to have goreleaser in path /go/bin/goreleaser, got empty output")
+	}
+
+	if !strings.Contains(goreleaserPathOut, "/go/bin/goreleaser") {
+		return Errorf("expected to have goreleaser "+
+			"in path /go/bin/goreleaser, got %s", goreleaserPathOut)
+	}
+
+	return nil
+}

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -99,6 +99,7 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestGoWithGoPrivate)
 	polTests.Go(m.TestGoWithGCCCompiler)
 	polTests.Go(m.TestGoWithGoTestSum)
+	polTests.Go(m.TestGoWithGoReleaserAndGolangCILint)
 	// Test HTTP specific functions.
 	polTests.Go(m.TestHTTPCurl)
 	polTests.Go(m.TestHTTPDoJSONAPICall)


### PR DESCRIPTION
Includes the following changes:
- Add a new test case `TestGoWithGoReleaserAndGolangCILint` to install and verify the installation of GoReleaser and GoLangCILint using the Go toolbox
- Add new methods `WithGoReleaser` and `WithGoLint` to the `ModuleTemplate` struct to install the respective tools
These changes provide a way to easily set up and use GoReleaser and GoLangCILint in the project, improving the development and release workflow.