### PR TITLE
ci: Install and run GolangCI Lint in CI workflow

### DIFF
--- a/.github/workflows/ci-daggy-codegen.yml
+++ b/.github/workflows/ci-daggy-codegen.yml
@@ -113,6 +113,22 @@ jobs:
                   echo "✅ Module reloaded successfully"
                   dagger call && dagger functions
 
+            - name: 🛠️ Install golangci-lint
+              run: |
+                  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
+                  sudo mv ./bin/golangci-lint /usr/local/bin/golangci-lint
+                  golangci-lint --version
+
+            - name: 🧹 Run GolangCI Lint
+              run: |
+                  echo "Running Go (GolangCI)... 🧹"
+                  cd ${{ env.MODULE_NAME }}
+                  golangci-lint run --config=../.golangci.yml --verbose
+                  cd tests
+                  golangci-lint run --config=../../.golangci.yml --verbose
+                  cd ../examples/go
+                  golangci-lint run --config=../../../.golangci.yml --verbose
+
             - name: 🧹 Run GolangCI Lint
               run: |
                   echo "Running Go (GolangCI)... 🧹"


### PR DESCRIPTION
This commit adds a step to the CI workflow to install and run GolangCI Lint for the Go code in the project. The changes include:

- Install the latest version of the golangci-lint tool
- Run golangci-lint on the main module, test, and example directories, using the configuration file at the root of the project

These changes help ensure code quality and catch potential issues early in the development process.