### PR TITLE
docs: Add CI badge for Daggy code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <h1 align="center">Daggerverse Modules 📦</h1>
 ---
+[![🏗️ CI CodeGen Daggy](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml/badge.svg)](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml)
 
 | Module                                         | Status | What it does?                                                                |
 |------------------------------------------------|--------|------------------------------------------------------------------------------|
@@ -16,6 +17,7 @@
 | [Terragrunt](terragrunt/README.md)             | ✅      | A simple [Terragrunt](https://terragrunt.gruntwork.io) module.               |
 
 ---
+
 
 ## Contributions 🤝
 


### PR DESCRIPTION
This commit adds a new CI badge for the Daggy code generation workflow to the README.md file. This badge will provide a visual indication of the status of the CI pipeline for the Daggy code generation process, which is an important part of the Daggerverse project.