### PR TITLE
feat: Add BaseWolfi method to create Wolfi Linux base image

### DIFF
--- a/.daggerx/templates/module/container.go.tmpl
+++ b/.daggerx/templates/module/container.go.tmpl
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/internal/dagger"
+)
 
 const (
 	defaultAlpineImage        = "alpine"
@@ -67,4 +71,54 @@ func (m *{{.module_name}}) BaseBusyBox(
 	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
 
 	return m.Base(imageURL)
+}
+
+// BaseWolfi sets the base image to a Wolfi Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Wolfi image to use. Optional parameter. Defaults to "latest".
+// - packages: Additional packages to install. Optional parameter.
+// - overlays: Overlay images to merge on top of the base. Optional parameter.
+//
+// Returns a pointer to the {{.module_name}} instance.
+func (m *{{.module_name}}) BaseWolfi(
+	// version is the version of the Wolfi image to use, e.g., "latest".
+	// +optional
+	version string,
+	// packages is the list of additional packages to install.
+	// +optional
+	packages []string,
+	// overlays are images to merge on top of the base.
+	// See https://twitter.com/ibuildthecloud/status/1721306361999597884
+	// +optional
+	overlays []*dagger.Container,
+) *{{.module_name}} {
+	if version == "" {
+		version = defaultImageVersionLatest
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", "cgr.dev/chainguard/wolfi-base", version)
+
+	m.Ctr = dag.
+		Container().
+		From(imageURL)
+
+	// Default apk add command
+	command := []string{"apk", "add", "--no-cache"}
+
+	// Concatenate additional packages to the command
+	if len(packages) > 0 {
+		command = append(command, packages...)
+	}
+
+	// Install default and additional packages
+	m.Ctr = m.Ctr.
+		WithExec(command)
+	// Apply overlays
+	for _, overlay := range overlays {
+		m.Ctr = m.Ctr.
+			WithDirectory("/", overlay.Rootfs())
+	}
+
+	return m
 }

--- a/.daggerx/templates/tests/container.go.tmpl
+++ b/.daggerx/templates/tests/container.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
 )
 
-// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
+// TestContainerWithUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
 //
 // This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
 // It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
@@ -17,7 +17,7 @@ import (
 //
 // Returns:
 //   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
-func (m *Tests) TestUbuntuBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithUbuntuBase(ctx context.Context) error {
 	targetModule := dag.
 		{{.module_name}}().
 		BaseUbuntu(dagger.{{.module_name}}BaseUbuntuOpts{Version: "22.04"})
@@ -37,7 +37,7 @@ func (m *Tests) TestUbuntuBase(ctx context.Context) error {
 	return nil
 }
 
-// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
+// TestContainerWithAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
 //
 // This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
 // It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
@@ -47,7 +47,7 @@ func (m *Tests) TestUbuntuBase(ctx context.Context) error {
 //
 // Returns:
 //   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
-func (m *Tests) TestAlpineBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithAlpineBase(ctx context.Context) error {
 	targetModule := dag.{{.module_name}}().
 		BaseAlpine(dagger.{{.module_name}}BaseAlpineOpts{Version: "3.17.3"})
 
@@ -64,7 +64,7 @@ func (m *Tests) TestAlpineBase(ctx context.Context) error {
 	return nil
 }
 
-// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
+// TestContainerWithBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
 //
 // This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
 // It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
@@ -74,7 +74,7 @@ func (m *Tests) TestAlpineBase(ctx context.Context) error {
 //
 // Returns:
 //   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
-func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithBusyBoxBase(ctx context.Context) error {
 	targetModule := dag.
 		{{.module_name}}().
 		BaseBusyBox(dagger.{{.module_name}}BaseBusyBoxOpts{Version: "1.35.0"})
@@ -89,6 +89,108 @@ func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
 
 	if !strings.Contains(out, "v1.35.0") {
 		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
+	}
+
+	return nil
+}
+
+// TestContainerWithWolfiBase tests that the target module is based on the Wolfi image.
+//
+// This function verifies that the target module is configured appropriately to use the base Wolfi image.
+// It runs a command to get the OS version and confirms it matches "Wolfi".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Wolfi image is not used or if the output is not as expected.
+//
+//nolint:cyclop // The test handles multiple commands and environments, requiring a longer function.
+func (m *Tests) TestContainerWithWolfiBase(ctx context.Context) error {
+	targetModule := dag.
+		{{.module_name}}().
+		BaseWolfi()
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"cat", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get Wolfi image")
+	}
+
+	if !strings.Contains(out, "Wolfi") {
+		return Errorf("expected Wolfi, got %s", out)
+	}
+
+	targetModuleWithInstalledPkgs := dag.
+		{{.module_name}}().
+		BaseWolfi(dagger.{{.module_name}}BaseWolfiOpts{
+			Packages: []string{"git", "curl", "wget"},
+		})
+
+		// Check if the Wolfi image has the installed packages
+	osOut, osErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"cat", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if osErr != nil {
+		return WrapError(osErr, "failed to get Wolfi image")
+	}
+
+	if !strings.Contains(osOut, "Wolfi") {
+		return Errorf("expected Wolfi, got %s", osOut)
+	}
+
+	// Check if git got installed
+	gitOut, gitErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+	if gitErr != nil {
+		return WrapError(gitErr, "failed to get git version")
+	}
+
+	if gitOut == "" {
+		return Errorf("expected to have git version output, got empty output")
+	}
+
+	if !strings.Contains(gitOut, "git version") {
+		return Errorf("expected git to be working correctly, got %s", gitOut)
+	}
+
+	// Check if curl got installed
+	curlOut, curlErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"curl", "--version"}).
+		Stdout(ctx)
+
+	if curlErr != nil {
+		return WrapError(curlErr, "failed to get curl version")
+	}
+
+	if curlOut == "" {
+		return Errorf("expected to have curl version output, got empty output")
+	}
+
+	if !strings.Contains(curlOut, "curl") {
+		return Errorf("expected curl to be working correctly, got %s", curlOut)
+	}
+
+	// Check if wget got installed
+	wgetOut, wgetErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"wget", "--version"}).
+		Stdout(ctx)
+
+	if wgetErr != nil {
+		return WrapError(wgetErr, "failed to get wget version")
+	}
+
+	if wgetOut == "" {
+		return Errorf("expected to have wget version output, got empty output")
+	}
+
+	if !strings.Contains(wgetOut, "GNU Wget") {
+		return Errorf("expected wget to be working correctly, got %s", wgetOut)
 	}
 
 	return nil

--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -51,13 +51,19 @@ func (m *Tests) getTestDir() *dagger.Directory {
 // TestAll executes all tests.
 //
 // This is a helper method for tests, in order to execute all tests.
+//
+//nolint:funlen // The test handles multiple commands and environments, requiring a longer function.
 func (m *Tests) TestAll(ctx context.Context) error {
-	polTests := pool.New().WithErrors().WithContext(ctx)
+	polTests := pool.
+		New().
+		WithErrors().
+		WithContext(ctx)
 
 	// Test different ways to configure the base container.
-	polTests.Go(m.TestUbuntuBase)
-	polTests.Go(m.TestAlpineBase)
-	polTests.Go(m.TestBusyBoxBase)
+	polTests.Go(m.TestContainerWithUbuntuBase)
+	polTests.Go(m.TestContainerWithAlpineBase)
+	polTests.Go(m.TestContainerWithBusyBoxBase)
+	polTests.Go(m.TestContainerWithWolfiBase)
 	polTests.Go(m.TestPassingEnvVarsInConstructor)
 	// Test built-in commands
 	polTests.Go(m.TestRunShellCMD)

--- a/module-template/container.go
+++ b/module-template/container.go
@@ -103,11 +103,17 @@ func (m *ModuleTemplate) BaseWolfi(
 		Container().
 		From(imageURL)
 
+	// Default apk add command
+	command := []string{"apk", "add", "--no-cache"}
+
+	// Concatenate additional packages to the command
+	if len(packages) > 0 {
+		command = append(command, packages...)
+	}
+
 	// Install default and additional packages
 	m.Ctr = m.Ctr.
-		WithExec([]string{"apk", "add", "--no-cache"}).
-		WithExec(packages)
-
+		WithExec(command)
 	// Apply overlays
 	for _, overlay := range overlays {
 		m.Ctr = m.Ctr.

--- a/module-template/container.go
+++ b/module-template/container.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
+)
 
 const (
 	defaultAlpineImage        = "alpine"
@@ -67,4 +71,48 @@ func (m *ModuleTemplate) BaseBusyBox(
 	imageURL := fmt.Sprintf("%s:%s", defaultBusyBoxImage, version)
 
 	return m.Base(imageURL)
+}
+
+// BaseWolfi sets the base image to a Wolfi Linux image and creates the base container.
+//
+// Parameters:
+// - version: The version of the Wolfi image to use. Optional parameter. Defaults to "latest".
+// - packages: Additional packages to install. Optional parameter.
+// - overlays: Overlay images to merge on top of the base. Optional parameter.
+//
+// Returns a pointer to the ModuleTemplate instance.
+func (m *ModuleTemplate) BaseWolfi(
+	// version is the version of the Wolfi image to use, e.g., "latest".
+	// +optional
+	version string,
+	// packages is the list of additional packages to install.
+	// +optional
+	packages []string,
+	// overlays are images to merge on top of the base.
+	// See https://twitter.com/ibuildthecloud/status/1721306361999597884
+	// +optional
+	overlays []*dagger.Container,
+) *ModuleTemplate {
+	if version == "" {
+		version = defaultImageVersionLatest
+	}
+
+	imageURL := fmt.Sprintf("%s:%s", "cgr.dev/chainguard/wolfi-base", version)
+
+	m.Ctr = dag.
+		Container().
+		From(imageURL)
+
+	// Install default and additional packages
+	m.Ctr = m.Ctr.
+		WithExec([]string{"apk", "add", "--no-cache"}).
+		WithExec(packages)
+
+	// Apply overlays
+	for _, overlay := range overlays {
+		m.Ctr = m.Ctr.
+			WithDirectory("/", overlay.Rootfs())
+	}
+
+	return m
 }

--- a/module-template/tests/container.go
+++ b/module-template/tests/container.go
@@ -118,7 +118,73 @@ func (m *Tests) TestContainerWithWolfiBase(ctx context.Context) error {
 	}
 
 	if !strings.Contains(out, "Wolfi") {
-		return WrapErrorf(err, "expected Wolfi, got %s", out)
+		return Errorf("expected Wolfi, got %s", out)
+	}
+
+	targetModuleWithInstalledPkgs := dag.
+		ModuleTemplate().
+		BaseWolfi(dagger.ModuleTemplateBaseWolfiOpts{
+			Packages: []string{"git", "curl", "wget"},
+		})
+
+		// Check if the Wolfi image has the installed packages
+	out, err = targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"cat", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get Wolfi image")
+	}
+
+	// Check if git got installed
+	gitOut, gitErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"git", "--version"}).
+		Stdout(ctx)
+
+	if gitErr != nil {
+		return WrapError(gitErr, "failed to get git version")
+	}
+
+	if gitOut == "" {
+		return Errorf("expected to have git version output, got empty output")
+	}
+
+	if !strings.Contains(gitOut, "git version") {
+		return Errorf("expected git to be working correctly, got %s", gitOut)
+	}
+
+	// Check if curl got installed
+	curlOut, curlErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"curl", "--version"}).
+		Stdout(ctx)
+
+	if curlErr != nil {
+		return WrapError(curlErr, "failed to get curl version")
+	}
+
+	if curlOut == "" {
+		return Errorf("expected to have curl version output, got empty output")
+	}
+
+	if !strings.Contains(curlOut, "curl") {
+		return Errorf("expected curl to be working correctly, got %s", curlOut)
+	}
+
+	// Check if wget got installed
+	wgetOut, wgetErr := targetModuleWithInstalledPkgs.Ctr().
+		WithExec([]string{"wget", "--version"}).
+		Stdout(ctx)
+
+	if wgetErr != nil {
+		return WrapError(wgetErr, "failed to get wget version")
+	}
+
+	if wgetOut == "" {
+		return Errorf("expected to have wget version output, got empty output")
+	}
+
+	if !strings.Contains(wgetOut, "GNU Wget") {
+		return Errorf("expected wget to be working correctly, got %s", wgetOut)
 	}
 
 	return nil

--- a/module-template/tests/container.go
+++ b/module-template/tests/container.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Excoriate/daggerverse/module-template/tests/internal/dagger"
 )
 
-// TestUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
+// TestContainerWithUbuntuBase tests that the target module is based on the Ubuntu 22.04 image.
 //
 // This function verifies that the target module is configured appropriately to use the base Ubuntu 22.04 image.
 // It runs a command to get the OS version and confirms it matches "Ubuntu 22.04".
@@ -17,7 +17,7 @@ import (
 //
 // Returns:
 //   - error: Returns an error if the Ubuntu image is not used or if the output is not as expected.
-func (m *Tests) TestUbuntuBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithUbuntuBase(ctx context.Context) error {
 	targetModule := dag.
 		ModuleTemplate().
 		BaseUbuntu(dagger.ModuleTemplateBaseUbuntuOpts{Version: "22.04"})
@@ -37,7 +37,7 @@ func (m *Tests) TestUbuntuBase(ctx context.Context) error {
 	return nil
 }
 
-// TestAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
+// TestContainerWithAlpineBase tests that the target module is based on the Alpine Linux v3.17.3 image.
 //
 // This function verifies that the target module is configured appropriately to use the base Alpine Linux v3.17.3 image.
 // It runs a command to get the OS version and confirms it matches "Alpine Linux v3.17.3".
@@ -47,7 +47,7 @@ func (m *Tests) TestUbuntuBase(ctx context.Context) error {
 //
 // Returns:
 //   - error: Returns an error if the Alpine image is not used or if the output is not as expected.
-func (m *Tests) TestAlpineBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithAlpineBase(ctx context.Context) error {
 	targetModule := dag.ModuleTemplate().
 		BaseAlpine(dagger.ModuleTemplateBaseAlpineOpts{Version: "3.17.3"})
 
@@ -64,7 +64,7 @@ func (m *Tests) TestAlpineBase(ctx context.Context) error {
 	return nil
 }
 
-// TestBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
+// TestContainerWithBusyBoxBase tests that the target module is based on the BusyBox v1.35.0 image.
 //
 // This function verifies that the target module is configured appropriately to use the base BusyBox v1.35.0 image.
 // It runs a command to get the OS version and confirms it matches "BusyBox v1.35.0".
@@ -74,7 +74,7 @@ func (m *Tests) TestAlpineBase(ctx context.Context) error {
 //
 // Returns:
 //   - error: Returns an error if the BusyBox image is not used or if the output is not as expected.
-func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
+func (m *Tests) TestContainerWithBusyBoxBase(ctx context.Context) error {
 	targetModule := dag.
 		ModuleTemplate().
 		BaseBusyBox(dagger.ModuleTemplateBaseBusyBoxOpts{Version: "1.35.0"})
@@ -89,6 +89,36 @@ func (m *Tests) TestBusyBoxBase(ctx context.Context) error {
 
 	if !strings.Contains(out, "v1.35.0") {
 		return WrapErrorf(err, "expected BusyBox v1.35.0, got %s", out)
+	}
+
+	return nil
+}
+
+// TestContainerWithWolfiBase tests that the target module is based on the Wolfi image.
+//
+// This function verifies that the target module is configured appropriately to use the base Wolfi image.
+// It runs a command to get the OS version and confirms it matches "Wolfi".
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if the Wolfi image is not used or if the output is not as expected.
+func (m *Tests) TestContainerWithWolfiBase(ctx context.Context) error {
+	targetModule := dag.
+		ModuleTemplate().
+		BaseWolfi()
+
+	out, err := targetModule.Ctr().
+		WithExec([]string{"cat", "/etc/os-release"}).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get Wolfi image")
+	}
+
+	if !strings.Contains(out, "Wolfi") {
+		return WrapErrorf(err, "expected Wolfi, got %s", out)
 	}
 
 	return nil

--- a/module-template/tests/container.go
+++ b/module-template/tests/container.go
@@ -104,6 +104,8 @@ func (m *Tests) TestContainerWithBusyBoxBase(ctx context.Context) error {
 //
 // Returns:
 //   - error: Returns an error if the Wolfi image is not used or if the output is not as expected.
+//
+//nolint:cyclop // The test handles multiple commands and environments, requiring a longer function.
 func (m *Tests) TestContainerWithWolfiBase(ctx context.Context) error {
 	targetModule := dag.
 		ModuleTemplate().
@@ -128,12 +130,16 @@ func (m *Tests) TestContainerWithWolfiBase(ctx context.Context) error {
 		})
 
 		// Check if the Wolfi image has the installed packages
-	out, err = targetModuleWithInstalledPkgs.Ctr().
+	osOut, osErr := targetModuleWithInstalledPkgs.Ctr().
 		WithExec([]string{"cat", "/etc/os-release"}).
 		Stdout(ctx)
 
-	if err != nil {
-		return WrapError(err, "failed to get Wolfi image")
+	if osErr != nil {
+		return WrapError(osErr, "failed to get Wolfi image")
+	}
+
+	if !strings.Contains(osOut, "Wolfi") {
+		return Errorf("expected Wolfi, got %s", osOut)
 	}
 
 	// Check if git got installed

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -51,8 +51,13 @@ func (m *Tests) getTestDir() *dagger.Directory {
 // TestAll executes all tests.
 //
 // This is a helper method for tests, in order to execute all tests.
+//
+//nolint:funlen // The test handles multiple commands and environments, requiring a longer function.
 func (m *Tests) TestAll(ctx context.Context) error {
-	polTests := pool.New().WithErrors().WithContext(ctx)
+	polTests := pool.
+		New().
+		WithErrors().
+		WithContext(ctx)
 
 	// Test different ways to configure the base container.
 	polTests.Go(m.TestContainerWithUbuntuBase)

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -55,9 +55,10 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests := pool.New().WithErrors().WithContext(ctx)
 
 	// Test different ways to configure the base container.
-	polTests.Go(m.TestUbuntuBase)
-	polTests.Go(m.TestAlpineBase)
-	polTests.Go(m.TestBusyBoxBase)
+	polTests.Go(m.TestContainerWithUbuntuBase)
+	polTests.Go(m.TestContainerWithAlpineBase)
+	polTests.Go(m.TestContainerWithBusyBoxBase)
+	polTests.Go(m.TestContainerWithWolfiBase)
 	polTests.Go(m.TestPassingEnvVarsInConstructor)
 	// Test built-in commands
 	polTests.Go(m.TestRunShellCMD)


### PR DESCRIPTION
- Add a new BaseWolfi method to the ModuleTemplate struct
- This method allows setting the base image to a Wolfi Linux image
- It accepts optional parameters for the Wolfi image version, additional packages to install, and overlay images to merge
- The method creates the base container with the specified Wolfi image and applies the additional configurations
- This new functionality expands the base image options for the ModuleTemplate, providing more flexibility for building container images