### PR TITLE
docs: Update README.md with new CI badge for module-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 <h1 align="center">Daggerverse Modules 📦</h1>
 ---
-[![🏗️ CI CodeGen Daggy](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml/badge.svg)](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml)
+
+[![🏗️ CI CodeGen Daggy](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml/badge.svg)](https://github.com/Excoriate/daggerverse/actions/workflows/ci-daggy-codegen.yml)[![CI module-template 🧹](https://github.com/Excoriate/daggerverse/actions/workflows/ci-mod-module-template.yaml/badge.svg)](https://github.com/Excoriate/daggerverse/actions/workflows/ci-mod-module-template.yaml)
+
 
 | Module                                         | Status | What it does?                                                                |
 |------------------------------------------------|--------|------------------------------------------------------------------------------|


### PR DESCRIPTION
The changes in this commit update the README.md file to include a new CI badge for the `ci-mod-module-template.yaml` workflow. This provides a visual indication of the status of the CI process for the `module-template` module.