### PR TITLE
fix: Remove unnecessary service tests from module template

### DIFF
--- a/.daggerx/templates/tests/main.go.tmpl
+++ b/.daggerx/templates/tests/main.go.tmpl
@@ -120,8 +120,6 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test Dagger specific functions.
 	polTests.Go(m.TestDaggerWithDaggerCLI)
 	polTests.Go(m.TestDaggerSetupDaggerInDagger)
-	// Test Services
-	polTests.Go(m.TestCreateService)
 
 	// From this point onwards, we're testing the specific functionality of the {{.module_name}} module.
 

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -120,8 +120,6 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	// Test Dagger specific functions.
 	polTests.Go(m.TestDaggerWithDaggerCLI)
 	polTests.Go(m.TestDaggerSetupDaggerInDagger)
-	// Test Services
-	polTests.Go(m.TestCreateService)
 
 	// From this point onwards, we're testing the specific functionality of the ModuleTemplate module.
 


### PR DESCRIPTION
The changes in this commit remove the `TestCreateService` function from the module template's test suite. This function was not providing any significant value and was not essential for testing the core functionality of the module. By removing it, the test suite becomes more focused and streamlined, making it easier to maintain and understand.