### PR TITLE
feat: Add a new recipe to call a function in a module with optional arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -193,3 +193,11 @@ dag mod *args:
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
   @cd {{mod}} && dagger {{args}}
+
+# Recipe that call a certain function by a module's name, passing extra arguments optionally
+callfn mod *args:
+  @echo "Calling a function in a certain module..."
+  @echo "Currently in {{mod}} module 📦, path=`pwd`"
+  @test -d {{mod}} || (echo "Module not found" && exit 1)
+  @cd {{mod}} && dagger functions
+  @cd {{mod}} && dagger call {{args}}


### PR DESCRIPTION
Add a new recipe called `callfn` that allows calling a function in a specific module, 
passing extra arguments optionally. This provides a more versatile way to interact with
module-specific functionality within the project.