### PR TITLE
feat: Add support for new Dagger features

### DIFF
--- a/.daggerx/daggy/dagger.json
+++ b/.daggerx/daggy/dagger.json
@@ -2,5 +2,5 @@
   "name": "modexample",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/.daggerx/daggy/dagger/go.mod
+++ b/.daggerx/daggy/dagger/go.mod
@@ -38,3 +38,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/dagindag/dagger.json
+++ b/dagindag/dagger.json
@@ -2,5 +2,5 @@
   "name": "dagindag",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/dagindag/dagger/go.mod
+++ b/dagindag/dagger/go.mod
@@ -42,3 +42,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/gitlab-cicd-vars/dagger.json
+++ b/gitlab-cicd-vars/dagger.json
@@ -2,5 +2,5 @@
   "name": "gitlab-cicd-vars",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/gitlab-cicd-vars/dagger/dagger.gen.go
+++ b/gitlab-cicd-vars/dagger/dagger.gen.go
@@ -9,13 +9,14 @@ import (
 	"log/slog"
 	"os"
 
-	"gitlabCICDVars/internal/dagger"
-	"gitlabCICDVars/internal/telemetry"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"gitlabCICDVars/internal/dagger"
+	"gitlabCICDVars/internal/querybuilder"
+	"gitlabCICDVars/internal/telemetry"
 )
 
 var dag = dagger.Connect()
@@ -33,7 +34,7 @@ func setMarshalContext(ctx context.Context) {
 	dagger.SetMarshalContext(ctx)
 }
 
-type DaggerObject = dagger.DaggerObject
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 type ExecError = dagger.ExecError
 

--- a/gitlab-cicd-vars/dagger/go.mod
+++ b/gitlab-cicd-vars/dagger/go.mod
@@ -44,3 +44,11 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/goreleaser/dagger.json
+++ b/goreleaser/dagger.json
@@ -2,5 +2,5 @@
   "name": "goreleaser",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/goreleaser/dagger/go.mod
+++ b/goreleaser/dagger/go.mod
@@ -45,3 +45,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/module-template/dagger.json
+++ b/module-template/dagger.json
@@ -10,5 +10,5 @@
     "examples/go"
   ],
   "source": ".",
-  "engineVersion": "v0.12.5"
+  "engineVersion": "v0.12.7"
 }

--- a/module-template/examples/go/dagger.json
+++ b/module-template/examples/go/dagger.json
@@ -14,5 +14,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.5"
+  "engineVersion": "v0.12.7"
 }

--- a/module-template/examples/go/go.mod
+++ b/module-template/examples/go/go.mod
@@ -44,3 +44,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/module-template/go.mod
+++ b/module-template/go.mod
@@ -53,3 +53,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/module-template/tests/dagger.json
+++ b/module-template/tests/dagger.json
@@ -14,5 +14,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.5"
+  "engineVersion": "v0.12.7"
 }

--- a/module-template/tests/go.mod
+++ b/module-template/tests/go.mod
@@ -44,3 +44,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/precommit/dagger.json
+++ b/precommit/dagger.json
@@ -2,5 +2,5 @@
   "name": "precommit",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/precommit/dagger/go.mod
+++ b/precommit/dagger/go.mod
@@ -39,3 +39,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/terragrunt/dagger.json
+++ b/terragrunt/dagger.json
@@ -2,5 +2,5 @@
   "name": "terragrunt",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/terragrunt/dagger/go.mod
+++ b/terragrunt/dagger/go.mod
@@ -45,3 +45,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/terratest/dagger.json
+++ b/terratest/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/terratest/dagger/dagger.gen.go
+++ b/terratest/dagger/dagger.gen.go
@@ -9,13 +9,14 @@ import (
 	"log/slog"
 	"os"
 
-	"Terratest/internal/dagger"
-	"Terratest/internal/telemetry"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"Terratest/internal/dagger"
+	"Terratest/internal/querybuilder"
+	"Terratest/internal/telemetry"
 )
 
 var dag = dagger.Connect()
@@ -33,7 +34,7 @@ func setMarshalContext(ctx context.Context) {
 	dagger.SetMarshalContext(ctx)
 }
 
-type DaggerObject = dagger.DaggerObject
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 type ExecError = dagger.ExecError
 

--- a/terratest/dagger/go.mod
+++ b/terratest/dagger/go.mod
@@ -53,3 +53,11 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/terratest/dagger/internal/dagger/dagger.gen.go
+++ b/terratest/dagger/internal/dagger/dagger.gen.go
@@ -49,7 +49,7 @@ func assertNotNil(argName string, value any) {
 	}
 }
 
-type DaggerObject querybuilder.GraphQLMarshaller
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 // getCustomError parses a GraphQL error into a more specific error type.
 func getCustomError(err error) error {
@@ -3568,6 +3568,7 @@ type File struct {
 	query *querybuilder.Selection
 
 	contents *string
+	digest   *string
 	export   *string
 	id       *FileID
 	name     *string
@@ -3595,6 +3596,31 @@ func (r *File) Contents(ctx context.Context) (string, error) {
 		return *r.contents, nil
 	}
 	q := r.query.Select("contents")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// FileDigestOpts contains options for File.Digest
+type FileDigestOpts struct {
+	// If true, exclude metadata from the digest.
+	ExcludeMetadata bool
+}
+
+// Return the file's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine.
+func (r *File) Digest(ctx context.Context, opts ...FileDigestOpts) (string, error) {
+	if r.digest != nil {
+		return *r.digest, nil
+	}
+	q := r.query.Select("digest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `excludeMetadata` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExcludeMetadata) {
+			q = q.Arg("excludeMetadata", opts[i].ExcludeMetadata)
+		}
+	}
 
 	var response string
 
@@ -3884,6 +3910,10 @@ type FunctionWithArgOpts struct {
 	Description string
 	// A default value to use for this argument if not explicitly set by the caller, if any
 	DefaultValue JSON
+	// If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
+	DefaultPath string
+	// Patterns to ignore when loading the contextual argument value.
+	Ignore []string
 }
 
 // Returns the function with the provided argument
@@ -3898,6 +3928,14 @@ func (r *Function) WithArg(name string, typeDef *TypeDef, opts ...FunctionWithAr
 		// `defaultValue` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DefaultValue) {
 			q = q.Arg("defaultValue", opts[i].DefaultValue)
+		}
+		// `defaultPath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DefaultPath) {
+			q = q.Arg("defaultPath", opts[i].DefaultPath)
+		}
+		// `ignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Ignore) {
+			q = q.Arg("ignore", opts[i].Ignore)
 		}
 	}
 	q = q.Arg("name", name)
@@ -3924,6 +3962,7 @@ func (r *Function) WithDescription(description string) *Function {
 type FunctionArg struct {
 	query *querybuilder.Selection
 
+	defaultPath  *string
 	defaultValue *JSON
 	description  *string
 	id           *FunctionArgID
@@ -3934,6 +3973,19 @@ func (r *FunctionArg) WithGraphQLQuery(q *querybuilder.Selection) *FunctionArg {
 	return &FunctionArg{
 		query: q,
 	}
+}
+
+// Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory
+func (r *FunctionArg) DefaultPath(ctx context.Context) (string, error) {
+	if r.defaultPath != nil {
+		return *r.defaultPath, nil
+	}
+	q := r.query.Select("defaultPath")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A default value to use for this argument when not explicitly set by the caller, if any.
@@ -4009,6 +4061,16 @@ func (r *FunctionArg) UnmarshalJSON(bs []byte) error {
 	}
 	*r = *dag.LoadFunctionArgFromID(FunctionArgID(id))
 	return nil
+}
+
+// Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.
+func (r *FunctionArg) Ignore(ctx context.Context) ([]string, error) {
+	q := r.query.Select("ignore")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The name of the argument in lowerCamelCase format.
@@ -4395,8 +4457,10 @@ func (r *GeneratedCode) WithVCSIgnoredPaths(paths []string) *GeneratedCode {
 type GitModuleSource struct {
 	query *querybuilder.Selection
 
+	cloneRef    *string
 	cloneURL    *string
 	commit      *string
+	htmlRepoURL *string
 	htmlURL     *string
 	id          *GitModuleSourceID
 	root        *string
@@ -4410,7 +4474,22 @@ func (r *GitModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *GitModule
 	}
 }
 
+// The ref to clone the root of the git repo from
+func (r *GitModuleSource) CloneRef(ctx context.Context) (string, error) {
+	if r.cloneRef != nil {
+		return *r.cloneRef, nil
+	}
+	q := r.query.Select("cloneRef")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // The URL to clone the root of the git repo from
+//
+// Deprecated: Use CloneRef instead. CloneRef supports both URL-style and SCP-like SSH references
 func (r *GitModuleSource) CloneURL(ctx context.Context) (string, error) {
 	if r.cloneURL != nil {
 		return *r.cloneURL, nil
@@ -4443,6 +4522,19 @@ func (r *GitModuleSource) ContextDirectory() *Directory {
 	return &Directory{
 		query: q,
 	}
+}
+
+// The URL to access the web view of the repository (e.g., GitHub, GitLab, Bitbucket)
+func (r *GitModuleSource) HTMLRepoURL(ctx context.Context) (string, error) {
+	if r.htmlRepoURL != nil {
+		return *r.htmlRepoURL, nil
+	}
+	q := r.query.Select("htmlRepoURL")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The URL to the source's git repo in a web browser
@@ -5209,6 +5301,7 @@ type LocalModuleSource struct {
 	query *querybuilder.Selection
 
 	id          *LocalModuleSourceID
+	relHostPath *string
 	rootSubpath *string
 }
 
@@ -5274,6 +5367,19 @@ func (r *LocalModuleSource) UnmarshalJSON(bs []byte) error {
 	}
 	*r = *dag.LoadLocalModuleSourceFromID(LocalModuleSourceID(id))
 	return nil
+}
+
+// The relative path to the module root from the host directory
+func (r *LocalModuleSource) RelHostPath(ctx context.Context) (string, error) {
+	if r.relHostPath != nil {
+		return *r.relHostPath, nil
+	}
+	q := r.query.Select("relHostPath")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
@@ -6148,6 +6254,27 @@ func (r *ModuleSource) WithContextDirectory(dir *Directory) *ModuleSource {
 func (r *ModuleSource) WithDependencies(dependencies []*ModuleDependency) *ModuleSource {
 	q := r.query.Select("withDependencies")
 	q = q.Arg("dependencies", dependencies)
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
+// ModuleSourceWithInitOpts contains options for ModuleSource.WithInit
+type ModuleSourceWithInitOpts struct {
+	// Merge module dependencies into the current project's
+	Merge bool
+}
+
+// Sets module init arguments
+func (r *ModuleSource) WithInit(opts ...ModuleSourceWithInitOpts) *ModuleSource {
+	q := r.query.Select("withInit")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `merge` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Merge) {
+			q = q.Arg("merge", opts[i].Merge)
+		}
+	}
 
 	return &ModuleSource{
 		query: q,
@@ -7273,6 +7400,8 @@ func (r *Client) ModuleDependency(source *ModuleSource, opts ...ModuleDependency
 type ModuleSourceOpts struct {
 	// If true, enforce that the source is a stable version for source kinds that support versioning.
 	Stable bool
+	// The relative path to the module root from the host directory
+	RelHostPath string
 }
 
 // Create a new module source instance from a source ref string.
@@ -7282,6 +7411,10 @@ func (r *Client) ModuleSource(refString string, opts ...ModuleSourceOpts) *Modul
 		// `stable` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Stable) {
 			q = q.Arg("stable", opts[i].Stable)
+		}
+		// `relHostPath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RelHostPath) {
+			q = q.Arg("relHostPath", opts[i].RelHostPath)
 		}
 	}
 	q = q.Arg("refString", refString)
@@ -8426,7 +8559,7 @@ func getClientParams() (graphql.Client, *querybuilder.Selection) {
 			r = r.WithContext(fallbackSpanContext(r.Context()))
 
 			// propagate span context via headers (i.e. for Dagger-in-Dagger)
-			otel.GetTextMapPropagator().Inject(r.Context(), propagation.HeaderCarrier(r.Header))
+			telemetry.Propagator.Inject(r.Context(), propagation.HeaderCarrier(r.Header))
 
 			return dialTransport.RoundTrip(r)
 		}),
@@ -8440,7 +8573,7 @@ func fallbackSpanContext(ctx context.Context) context.Context {
 	if trace.SpanContextFromContext(ctx).IsValid() {
 		return ctx
 	}
-	return otel.GetTextMapPropagator().Extract(ctx, telemetry.NewEnvCarrier(true))
+	return telemetry.Propagator.Extract(ctx, telemetry.NewEnvCarrier(true))
 }
 
 // TODO: pollutes namespace, move to non internal package in dagger.io/dagger

--- a/tflint/dagger.json
+++ b/tflint/dagger.json
@@ -2,5 +2,5 @@
   "name": "tflint",
   "sdk": "go",
   "source": "dagger",
-  "engineVersion": "v0.12.4"
+  "engineVersion": "v0.12.7"
 }

--- a/tflint/dagger/dagger.gen.go
+++ b/tflint/dagger/dagger.gen.go
@@ -9,13 +9,14 @@ import (
 	"log/slog"
 	"os"
 
-	"TFLint/internal/dagger"
-	"TFLint/internal/telemetry"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"TFLint/internal/dagger"
+	"TFLint/internal/querybuilder"
+	"TFLint/internal/telemetry"
 )
 
 var dag = dagger.Connect()
@@ -33,7 +34,7 @@ func setMarshalContext(ctx context.Context) {
 	dagger.SetMarshalContext(ctx)
 }
 
-type DaggerObject = dagger.DaggerObject
+type DaggerObject = querybuilder.GraphQLMarshaller
 
 type ExecError = dagger.ExecError
 

--- a/tflint/dagger/go.mod
+++ b/tflint/dagger/go.mod
@@ -38,3 +38,11 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1 // indirect
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0


### PR DESCRIPTION
- Add support for new Dagger features, including:
  - `File.Digest` method to get the digest of a file, with an optional `ExcludeMetadata` flag
  - `FunctionArg.Ignore` method to get the ignore patterns for a directory input
- Update OpenTelemetry dependencies to the latest version (v1.24.0)
- Update Dagger engine version to v0.12.7 in the precommit and modexample projects
- Refactor internal code to use the `querybuilder` package instead of the deprecated `dagger` package