### PR TITLE
feat: Add support for Dagger versions 0.12.6 and 0.12.7 in CI

### DIFF
--- a/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
+++ b/.daggerx/templates/github/workflows/mod-template-ci.yaml.tmpl
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         name: Lint {{.module_name_pkg}} on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
         steps:
@@ -159,7 +159,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run Tests 🧪 in {{.module_name_pkg}} on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.5]
+                dagversion: [0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in {{.module_name_pkg}}/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-mod-gotoolbox.yaml
+++ b/.github/workflows/ci-mod-gotoolbox.yaml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         name: Lint gotoolbox on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
         steps:
@@ -159,7 +159,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run Tests 🧪 in gotoolbox on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.5]
+                dagversion: [0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in gotoolbox/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-mod-module-template.yaml
+++ b/.github/workflows/ci-mod-module-template.yaml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         name: Lint module-template on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
         steps:
@@ -159,7 +159,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4]
+                dagversion: [0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run Tests 🧪 in module-template on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.12.5]
+                dagversion: [0.12.7]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in module-template/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest


### PR DESCRIPTION
The commit adds support for Dagger versions 0.12.6 and 0.12.7 in the CI pipeline for the `{{.module_name_pkg}}` module. The changes update the `dagversion` matrix in the `Run Tests`, `Run recipes`, and `Lint {{.module_name_pkg}}` jobs to include the new Dagger versions.