### PR TITLE
feat: Improve dagger development workflow

### DIFF
--- a/.daggerx/daggy/src/main.rs
+++ b/.daggerx/daggy/src/main.rs
@@ -71,8 +71,8 @@ fn create_module(module: &str) -> Result<(), Error> {
     initialize_module(&new_module)?;
 
     // Initialize examples and tests
-    initialize_examples(&new_module)?;
     initialize_tests(&new_module)?;
+    initialize_examples(&new_module)?;
 
     // Copy README and LICENSE files
     copy_readme_and_license(&new_module)?;
@@ -312,7 +312,10 @@ fn initialize_module(module_cfg: &NewDaggerModule) -> Result<(), Error> {
     run_command_with_output(&go_mod_edit_command, ".")?;
 
     // Run dagger develop
-    run_command_with_output(&format!("dagger develop -m {}", module_cfg.name), ".")?;
+    // run_command_with_output(&format!("dagger develop -m {}", module_cfg.name), ".")?;
+    // FIXME: Check consistency across other cases. It's required to run dagger develop without arguments, since
+    // it's running in the module's directory.
+    run_command_with_output("dagger develop", ".")?;
 
     // Change back to the root directory
     env::set_current_dir("..")?;
@@ -352,7 +355,8 @@ fn initialize_examples(module_cfg: &NewDaggerModule) -> Result<(), Error> {
 
     // Run dagger install and develop
     run_command_with_output("dagger install ../../", ".")?;
-    run_command_with_output("dagger develop -m go", ".")?;
+    // run_command_with_output("dagger develop -m go", ".")?;
+    run_command_with_output("dagger develop", ".")?;
 
     // Change back to the root directory
     env::set_current_dir("../../..")?;
@@ -406,7 +410,8 @@ fn initialize_tests(module_cfg: &NewDaggerModule) -> Result<(), Error> {
 
     // Run dagger install and develop
     run_command_with_output("dagger install ../", ".")?;
-    run_command_with_output("dagger develop -m tests", ".")?;
+    // run_command_with_output("dagger develop -m tests", ".")?;
+    run_command_with_output("dagger develop", ".")?;
 
     // Change back to the root directory
     env::set_current_dir("../..")?;


### PR DESCRIPTION
- Update `dagger develop` commands to run without module flags
- Reorder initialization of examples and tests to ensure consistent behavior
- Fix inconsistencies in dagger develop commands across different functions

The changes in this commit aim to improve the dagger development workflow by:

1. Updating the `dagger develop` commands to run without module flags. This ensures a consistent behavior across different functions (`initialize_module`, `initialize_examples`, `initialize_tests`) and simplifies the command execution.

2. Reordering the initialization of examples and tests to ensure a consistent order. Previously, the order was different in the `create_module` function, which could lead to unexpected behavior.

3. Fixing a small inconsistency in the `initialize_module` function, where the `dagger develop` command was still using the module name flag, while the other functions had it removed.

These changes should help to streamline the dagger development workflow and make the codebase more consistent.