### PR TITLE
feat: Update Dagger CLI version to v0.12.7

### DIFF
--- a/module-template/dagger.go
+++ b/module-template/dagger.go
@@ -15,8 +15,8 @@ import (
 //
 // Example:
 //
-//	getDaggerInstallCMDByVersion("v0.12.1")
-//	=> `cd / && DAGGER_VERSION="v0.12.1" curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION="v0.12.1" sh`
+//	getDaggerInstallCMDByVersion("v0.12.7")
+//	=> `cd / && DAGGER_VERSION="v0.12.7" curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION="v0.12.7" sh`
 func getDaggerInstallCMDByVersion(version string) string {
 	return strings.Join([]string{
 		"cd /",
@@ -31,7 +31,7 @@ func getDaggerInstallCMDByVersion(version string) string {
 // WithDaggerCLIAlpine sets up the Dagger CLI entry point for Alpine within the ModuleTemplate.
 //
 // Parameters:
-//   - version: The version of the Dagger Engine to use, e.g., "v0.12.1".
+//   - version: The version of the Dagger Engine to use, e.g., "v0.12.7".
 //
 // This method performs the following steps:
 //  1. Generates a shell command to install the Dagger CLI using the specified version.
@@ -58,7 +58,7 @@ func (m *ModuleTemplate) WithDaggerCLIAlpine(version string) *ModuleTemplate {
 // WithDaggerCLIUbuntu sets up the Dagger CLI entry point for Ubuntu within the ModuleTemplate.
 //
 // Parameters:
-//   - version: The version of the Dagger Engine to use, e.g., "v0.12.1".
+//   - version: The version of the Dagger Engine to use, e.g., "v0.12.7".
 //
 // This method performs the following steps:
 //  1. Updates package lists and installs curl.
@@ -143,7 +143,7 @@ func (m *ModuleTemplate) validateDaggerVersion(dagVersion string) error {
 // container, and sets up the Docker service within the Dagger context.
 //
 // Parameters:
-//   - dagVersion: The version of the Dagger Engine to use, e.g., "v0.12.5".
+//   - dagVersion: The version of the Dagger Engine to use, e.g., "v0.12.7".
 //   - dockerVersion: The version of the Docker Engine to use, e.g., "24.0". This is optional.
 //
 // Returns:

--- a/module-template/tests/dagger.go
+++ b/module-template/tests/dagger.go
@@ -22,7 +22,7 @@ import (
 //	  log.Fatalf("Test failed with error: %v", err)
 //	}
 func (m *Tests) TestDaggerWithDaggerCLI(ctx context.Context) error {
-	versions := []string{"v0.12.1", "v0.12.2", "v0.12.3", "v0.12.4", "v0.12.5"}
+	versions := []string{"v0.12.1", "v0.12.2", "v0.12.3", "v0.12.4", "v0.12.5", "v0.12.6", "v0.12.7"}
 
 	for _, version := range versions {
 		if err := m.testDaggerVersion(ctx, version); err != nil {


### PR DESCRIPTION
Upgrade the Dagger CLI version used throughout the module-template codebase from v0.12.1 to v0.12.7. This includes:

- Updating the `getDaggerInstallCMDByVersion` function to use the new version.
- Expanding the list of tested versions in the `TestDaggerWithDaggerCLI` test to include v0.12.6 and v0.12.7.
- Updating the documentation comments for the `WithDaggerCLIAlpine` and `WithDaggerCLIUbuntu` methods to reflect the new version.
- Updating the version used in the `validateDaggerVersion` method.

This change ensures the module-template is using the latest stable version of the Dagger CLI.