### PR TITLE
fix: Increase timeout and set concurrency for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,8 @@
 run:
     tests: false
     modules-download-mode: readonly
-    timeout: 240s
+    timeout: 2m
+    concurrency: 2
 linters-settings:
     gomoddirectives:
         replace-allow-list:


### PR DESCRIPTION
The changes in this commit increase the timeout for running golangci-lint from 240 seconds to 2 minutes, and set the concurrency to 2. This should help to address any issues with long-running linting tasks, and improve the overall performance of the linting process.