### PR TITLE
feat: Add Docker availability check before running `dagger develop`

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,6 +100,10 @@ reloadmod mod:
   @echo "Running Dagger development in a given module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
+  @if ! docker info > /dev/null 2>&1; then \
+    echo "Docker is not running. Please start Docker and try again."; \
+    exit 1; \
+  fi
   @cd {{mod}} && dagger develop
   @echo "Module reloaded successfully ✅"
 


### PR DESCRIPTION
The commit adds a check for the availability of Docker before running the `dagger develop` command in the `reloadmod` task. If Docker is not running, the task will exit with an error message, prompting the user to start Docker and try again.

This change ensures that the development workflow is more reliable and prevents potential issues when the `dagger develop` command is executed without a running Docker instance.