### PR TITLE
feat: Add .aider and AI markdown files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,11 @@
 /target/
 Cargo.lock
 /.daggerx/daggy/target/
-.aider*
-/internal/telemetry
 
+/internal/telemetry
 .idea
+
+# AI
+.aider*
+AI/**.md
+


### PR DESCRIPTION
This commit updates the .gitignore file to include the .aider directory and any Markdown files in the AI directory. This ensures that these files and directories are excluded from the Git repository, as they are likely temporary or generated artifacts.