### PR TITLE
Here's a clear and concise commit message summarizing the changes:

### DIFF
--- a/module-template-light/apis.go
+++ b/module-template-light/apis.go
@@ -181,7 +181,7 @@ func (m *ModuleTemplateLight) WithClonedGitRepo(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
-	token string,
+	token *dagger.Secret,
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,

--- a/module-template-light/content.go
+++ b/module-template-light/content.go
@@ -57,7 +57,7 @@ func (m *ModuleTemplateLight) CloneGitRepo(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
-	token string,
+	token *dagger.Secret,
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
@@ -67,22 +67,39 @@ func (m *ModuleTemplateLight) CloneGitRepo(
 		vcs = "github"
 	}
 
-	// Determine the token name based on the VCS.
-	var tokenName string
-	if vcs == "gitlab" {
-		tokenName = "GITLAB_TOKEN"
-	} else { // This branch handles both "github" and the default case.
-		tokenName = "GITHUB_TOKEN" //nolint:gosec // This is a constant string.
-	}
 	// Initialize the Git clone request.
 	gitCloneRequest := dag.Git(repoURL)
 
 	// If a token is provided, set it as a secret and attach it to the clone request.
-	if token != "" {
-		tokenSecret := dag.SetSecret(tokenName, token)
-		gitCloneRequest = gitCloneRequest.WithAuthToken(tokenSecret)
+	if token != nil {
+		gitCloneRequest = gitCloneRequest.
+			WithAuthToken(dag.
+				SetSecret(m.getTokenNameByVcs(vcs), m.getTokenValueBySecret(token)))
 	}
 
 	// Perform the Git clone operation and return the resulting directory.
-	return gitCloneRequest.Head().Tree()
+	return gitCloneRequest.
+		Head().
+		Tree()
+}
+
+// getTokenNameByVcs returns the appropriate token name based on the VCS type.
+// If the VCS is "gitlab", it returns "GITLAB_TOKEN". Otherwise, it returns "GITHUB_TOKEN".
+func (m *ModuleTemplateLight) getTokenNameByVcs(vcs string) string {
+	if vcs == "gitlab" {
+		return "GITLAB_TOKEN"
+	}
+
+	return "GITHUB_TOKEN"
+}
+
+// getTokenValueBySecret retrieves the plaintext value of the provided secret.
+// If an error occurs while retrieving the plaintext, it returns an empty string.
+func (m *ModuleTemplateLight) getTokenValueBySecret(secret *dagger.Secret) string {
+	plainTxtToken, err := secret.Plaintext(nil)
+	if err != nil {
+		return ""
+	}
+
+	return plainTxtToken
 }

--- a/module-template/apis.go
+++ b/module-template/apis.go
@@ -219,7 +219,7 @@ func (m *ModuleTemplate) WithClonedGitRepo(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
-	token string,
+	token *dagger.Secret,
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,


### PR DESCRIPTION
feat: Refactor Git clone functionality with token handling

The changes in this commit refactor the Git clone functionality in the `ModuleTemplate` and `ModuleTemplateLight` structs. The main improvements are:

1. The `token` parameter is now a `*dagger.Secret` instead of a string, allowing the use of secrets for authentication.
2. The logic to determine the appropriate token name (GITHUB_TOKEN or GITLAB_TOKEN) has been extracted into a separate method, `getTokenNameByVcs()`.
3. The method `getTokenValueBySecret()` has been added to retrieve the plaintext value of the provided secret.
4. The Git clone request is now constructed and configured in a more readable and maintainable way, using method chaining.

These changes improve the overall flexibility and security of the Git clone functionality in the module templates.