### PR TITLE
feat: Add missing context.TODO() to getTokenValueBySecret function

### DIFF
--- a/module-template-light/content.go
+++ b/module-template-light/content.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/Excoriate/daggerverse/module-template-light/internal/dagger"
@@ -96,7 +97,7 @@ func (m *ModuleTemplateLight) getTokenNameByVcs(vcs string) string {
 // getTokenValueBySecret retrieves the plaintext value of the provided secret.
 // If an error occurs while retrieving the plaintext, it returns an empty string.
 func (m *ModuleTemplateLight) getTokenValueBySecret(secret *dagger.Secret) string {
-	plainTxtToken, err := secret.Plaintext(nil)
+	plainTxtToken, err := secret.Plaintext(context.TODO())
 	if err != nil {
 		return ""
 	}

--- a/module-template/content.go
+++ b/module-template/content.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
@@ -96,7 +97,7 @@ func (m *ModuleTemplate) getTokenNameByVcs(vcs string) string {
 // getTokenValueBySecret retrieves the plaintext value of the provided secret.
 // If an error occurs while retrieving the plaintext, it returns an empty string.
 func (m *ModuleTemplate) getTokenValueBySecret(secret *dagger.Secret) string {
-	plainTxtToken, err := secret.Plaintext(nil)
+	plainTxtToken, err := secret.Plaintext(context.TODO())
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
The changes in this commit are:

1. Added `"context"` import to both `module-template-light/content.go` and `module-template/content.go`.
2. Updated the `getTokenValueBySecret` function in both `ModuleTemplateLight` and `ModuleTemplate` to use `context.TODO()` instead of `nil`.

These changes ensure that the `Plaintext` function call on the `dagger.Secret` object is provided with a valid `context.Context` argument, which is required for proper error handling and potential future extensions.