### PR TITLE
feat: Bump DAG module version to 0.13.3

### DIFF
--- a/.github/workflows/cd-bump-publish-dag-manual.yml
+++ b/.github/workflows/cd-bump-publish-dag-manual.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
     GO_VERSION: ~1.22
-    DAG_VERSION: 0.12.5
+    DAG_VERSION: 0.13.3
 
 jobs:
     publish-and-bump:

--- a/.github/workflows/cd-publish-dag-modules.yml
+++ b/.github/workflows/cd-publish-dag-modules.yml
@@ -9,7 +9,7 @@ on:
 
 env:
     GO_VERSION: ~1.22
-    DAG_VERSION: 0.12.5
+    DAG_VERSION: 0.13.3
 
 permissions:
     contents: write

--- a/.github/workflows/cd-publish-last-version-dag-module.yml
+++ b/.github/workflows/cd-publish-last-version-dag-module.yml
@@ -10,7 +10,7 @@ on:
 
 env:
     GO_VERSION: ~1.22
-    DAG_VERSION: 0.12.5
+    DAG_VERSION: 0.13.3
 
 permissions:
     contents: read

--- a/.github/workflows/cd-publish-specific-version.yml
+++ b/.github/workflows/cd-publish-specific-version.yml
@@ -13,7 +13,7 @@ on:
 
 env:
     GO_VERSION: ~1.22
-    DAG_VERSION: 0.12.5
+    DAG_VERSION: 0.13.3
 
 permissions:
     contents: write


### PR DESCRIPTION
The commit updates the DAG module version from 0.12.5 to 0.13.3 in the following GitHub Actions workflows:
- `cd-publish-dag-modules.yml`
- `cd-publish-last-version-dag-module.yml`
- `cd-bump-publish-dag-manual.yml`
- `cd-publish-specific-version.yml`

This change is to ensure the latest version of the DAG module is used in the CI/CD pipeline.