### PR TITLE
feat: Add new recipe to create modules with optional CI setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -158,14 +158,16 @@ cilocal mod: (reloadall mod) (golint mod) (test mod) (examplesgo mod) (ci-module
   @echo "Running the whole CI locally... 🚀"
 
 # Recipe to create a new module using Daggy (a rust CLI tool)
-create mod type='full':
+# Recipe to create a new module using Daggy (a rust CLI tool)
+create mod with-ci='false' type='full':
   @echo "Creating a new {{type}} module..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
+  @if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
 
 # Recipe to create a new light module using Daggy
-createlight mod:
-  @just create {{mod}} light
+createlight mod with-ci='false':
+  @just create {{mod}} with-ci={{with-ci}} type='light'
 
 # This recipe validate if the dagger module has the README.md file and the LICENSE file
 ci-module-docs mod:


### PR DESCRIPTION
Introduce a new recipe `create` that allows creating a new module with Daggy.
The recipe now has an optional `with-ci` parameter that, when set to `true`,
will also run the `cilocal` recipe for the newly created module.
Additionally, the `createlight` recipe has also been updated to support the
`with-ci` parameter.