### PR TITLE
feat: Add support for configuring cache volume options

### DIFF
--- a/.daggerx/templates/mod-full/module/apis.go.tmpl
+++ b/.daggerx/templates/mod-full/module/apis.go.tmpl
@@ -17,8 +17,6 @@ import (
 	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
-const netRcRootPath = "/root/.netrc"
-
 // WithEnvironmentVariable sets an environment variable in the container.
 //
 // Parameters:
@@ -78,42 +76,6 @@ func (m *{{.module_name}}) WithContainer(
 	m.Ctr = ctr
 
 	return m
-}
-
-// WithDockerService sets up the container with the Docker service.
-//
-// It sets up the container with the Docker service.
-// Parameters:
-//   - dockerVersion: The version of the Docker engine to use, e.g., "v20.10.17".
-//     Optional parameter. If not provided, a default version is used.
-func (m *{{.module_name}}) WithDockerService(
-	dockerVersion string,
-) *dagger.Service {
-	if dockerVersion == "" {
-		dockerVersion = dockerVersionDefault
-	}
-
-	dindImage := getDockerInDockerImage(dockerVersion)
-	dockerPort := 2375
-
-	return dag.Container().
-		From(dindImage).
-		WithMountedCache(
-			"/var/lib/docker",
-			dag.CacheVolume(dockerVersion+"-docker-lib"),
-			dagger.ContainerWithMountedCacheOpts{
-				Sharing: dagger.Private,
-			}).
-		WithExposedPort(dockerPort).
-		WithExec([]string{
-			"dockerd",
-			"--host=tcp://0.0.0.0:2375",
-			"--host=unix:///var/run/docker.sock",
-			"--tls=false",
-		}, dagger.ContainerWithExecOpts{
-			InsecureRootCapabilities: true,
-		}).
-		AsService()
 }
 
 // WithFileMountedInContainer adds a file to the container.
@@ -201,7 +163,7 @@ func (m *{{.module_name}}) WithDownloadedFile(
 	return m
 }
 
-// WithClonedGitRepo clones a Git repository and mounts it as a directory in the container.
+// WithClonedGitRepoHTTPS clones a Git repository and mounts it as a directory in the container.
 //
 // This method downloads a Git repository and mounts it as a directory in the container. It supports optional
 // authentication tokens for private repositories and can handle both GitHub and GitLab repositories.
@@ -215,7 +177,7 @@ func (m *{{.module_name}}) WithDownloadedFile(
 //
 // Returns:
 //   - *{{.module_name}}: The updated {{.module_name}} with the cloned repository mounted in the container.
-func (m *{{.module_name}}) WithClonedGitRepo(
+func (m *{{.module_name}}) WithClonedGitRepoHTTPS(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
@@ -223,12 +185,77 @@ func (m *{{.module_name}}) WithClonedGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *{{.module_name}} {
 	// Call the helper function to clone the repository.
-	clonedRepo := m.CloneGitRepo(repoURL, token, vcs)
+	clonedRepo := m.CloneGitRepoHTTPS(repoURL, token, vcs, authHeader, returnDir, branch, keepGitDir, tag, commit)
 
 	// Mount the cloned repository as a directory inside the container.
 	m.Ctr = m.Ctr.WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
+
+	return m
+}
+
+// WithClonedGitRepoSSH clones a git repository using SSH for authentication.
+//
+// Parameters:
+//   - repoURL: The URL of the git repository to clone.
+//   - sshSocket: The SSH socket to use for authentication.
+//   - sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//   - returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//   - branch: The branch to checkout. Optional parameter.
+//   - keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//
+// Returns:
+//   - *{{.module_name}}: The updated {{.module_name}} with the cloned repository mounted in the container.
+func (m *{{.module_name}}) WithClonedGitRepoSSH(
+	// repoURL is the URL of the git repository to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return. Optional parameter.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *{{.module_name}} {
+	// Call the helper function to clone the repository.
+	clonedRepo := m.CloneGitRepoSSH(repoURL, sshAuthSocket, sshKnownHosts, returnDir, branch, keepGitDir, tag, commit)
+
+	// Mount the cloned repository as a directory inside the container.
+	m.Ctr = m.
+		Ctr.
+		WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
 
 	return m
 }
@@ -262,24 +289,26 @@ func (m *{{.module_name}}) WithCacheBuster() *{{.module_name}} {
 // Returns:
 //   - *{{.module_name}}: The updated {{.module_name}} with the config file mounted in the container.
 func (m *{{.module_name}}) WithConfigFile(
-	// cfgPath is the path where the config file will be mounted.
+	// cfgFile is the config file to be mounted.
+	cfgFile *dagger.File,
+	// cfgPathInCtr is the path where the config file will be mounted.
 	// +optional
-	cfgPath string,
+	cfgPathInCtr string,
 	// setEnvVar is a string that set an environment variable in the container with the config file path.
 	// +optional
 	setEnvVar string,
-	// cfgFile is the config file to be mounted.
-	cfgFile *dagger.File) *{{.module_name}} {
-	if cfgPath == "" {
-		cfgPath = fixtures.MntPrefix
+) *{{.module_name}} {
+	if cfgPathInCtr == "" {
+		cfgPathInCtr = fixtures.MntPrefix
 	}
 
 	m.Ctr = m.Ctr.
-		WithMountedFile(cfgPath, cfgFile)
+		WithMountedFile(cfgPathInCtr, cfgFile)
 
 	if setEnvVar != "" {
-		setEnvVar = strings.ToUpper(setEnvVar)
-		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, cfgPath)
+		setEnvVar = strings.ToUpper(strings.TrimSpace(setEnvVar))
+		setEnvVar = strings.ReplaceAll(setEnvVar, "\\", "")
+		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, strings.TrimSpace(cfgPathInCtr))
 	}
 
 	return m
@@ -299,6 +328,15 @@ func (m *{{.module_name}}) WithCachedDirectory(
 	// setEnvVarWithCacheDirValue is the value to set the cache directory in the container.
 	// +optional
 	setEnvVarWithCacheDirValue string,
+	// cacheSharingMode is the sharing mode of the cache volume.
+	// +optional
+	cacheSharingMode dagger.CacheSharingMode,
+	// cacheVolumeRootDir is the root directory of the cache volume.
+	// +optional
+	cacheVolumeRootDir *dagger.Directory,
+	// cacheVolumeOwner is the owner of the cache volume.
+	// +optional
+	cacheVolumeOwner string,
 ) *{{.module_name}} {
 	// Define the cache volume
 	cacheVolume := dag.CacheVolume(path)
@@ -309,9 +347,22 @@ func (m *{{.module_name}}) WithCachedDirectory(
 		mountPath = filepath.Join(fixtures.MntPrefix, path)
 	}
 
+	cacheMountOpts := dagger.ContainerWithMountedCacheOpts{}
+	if cacheVolumeRootDir != nil {
+		cacheMountOpts.Source = cacheVolumeRootDir
+	}
+
+	if cacheVolumeOwner != "" {
+		cacheMountOpts.Owner = cacheVolumeOwner
+	}
+
+	if cacheSharingMode != "" {
+		cacheMountOpts.Sharing = cacheSharingMode
+	}
+
 	// Mount the cache volume in the container
 	m.Ctr = m.Ctr.
-		WithMountedCache(mountPath, cacheVolume)
+		WithMountedCache(mountPath, cacheVolume, cacheMountOpts)
 
 	// Set the environment variable if provided
 	if setEnvVarWithCacheDirValue != "" {
@@ -319,6 +370,91 @@ func (m *{{.module_name}}) WithCachedDirectory(
 		m.Ctr = m.
 			Ctr.
 			WithEnvVariable(envVarName, mountPath)
+	}
+
+	return m
+}
+
+// WithUserAsOwnerOfDirs sets the specified user (and optionally group) as the owner
+// of the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chown" command
+// within the container to change the ownership of each directory to the specified user (and optionally group).
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - group: The group to set as the owner of the directories. This is an optional parameter.
+//   - dirs: A slice of strings representing the directories to set the owner of. Each directory path should be
+//     specified relative to the container's filesystem.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the ownership of the specified directories changed.
+func (m *{{.module_name}}) WithUserAsOwnerOfDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// dirs is the directories to set the owner of.
+	dirs []string,
+	// group is the group to set as the owner of the directories.
+	// +optional
+	group string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given user.
+	// +optional
+	configureAsRoot bool,
+) *{{.module_name}} {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		if group != "" {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user + ":" + group, dir})
+		} else {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user, dir})
+		}
+	}
+
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser(user)
+	}
+
+	return m
+}
+
+// WithUserWithPermissionsOnDirs sets the specified permissions on the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chmod" command
+// within the container to change the permissions of each directory to the specified mode.
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - mode: The permissions to set on the directories. This should be a valid mode string (e.g., "0777").
+//   - dirs: A slice of strings representing the directories to set the permissions of. Each directory path should be
+//     specified relative to the container's filesystem.
+//   - configureAsRoot: Whether to configure the directories as root, and then it'll use the given mode.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the permissions of the specified directories changed.
+func (m *{{.module_name}}) WithUserWithPermissionsOnDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// mode is the permissions to set on the directories.
+	mode string,
+	// dirs is the directories to set the permissions of.
+	dirs []string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given mode.
+	// +optional
+	configureAsRoot bool,
+) *{{.module_name}} {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		m.Ctr = m.Ctr.WithExec([]string{"chmod", "-R", mode, dir})
+	}
+
+	if configureAsRoot && user != "" {
+		m.Ctr = m.Ctr.WithUser(user)
 	}
 
 	return m

--- a/.daggerx/templates/mod-full/module/content.go.tmpl
+++ b/.daggerx/templates/mod-full/module/content.go.tmpl
@@ -39,7 +39,7 @@ func (m *{{.module_name}}) DownloadFile(
 	return fileDownloaded
 }
 
-// CloneGitRepo clones a Git repository into a Dagger Directory.
+// CloneGitRepoHTTPS clones a Git repository into a Dagger Directory.
 //
 // Parameters:
 //   - repoURL: The URL of the git repository to clone (e.g., "https://github.com/user/repo").
@@ -47,13 +47,20 @@ func (m *{{.module_name}}) DownloadFile(
 //     not provided, the repository will be cloned without authentication.
 //   - vcs: (Optional) The version control system (VCS) to use for
 //     authentication. Defaults to "github". Supported values are "github" and "gitlab".
+//   - authHeader: (Optional) The authentication header to use for authentication. If
+//     not provided, the repository will be cloned without authentication.
+//   - returnDir: (Optional) A string that indicates the directory path of the repository to return.
+//   - branch: (Optional) The branch to checkout. If not provided, the default branch will be checked out.
+//   - keepGitDir: (Optional) A boolean that indicates if the .git directory should be kept. Defaults to false.
+//   - tag: (Optional) The tag to checkout. If not provided, no tag will be checked out.
+//   - commit: (Optional) The commit to checkout. If not provided, the latest commit will be checked out.
 //
 // Returns:
 //   - *dagger.Directory: A directory object representing the cloned repository.
 //
 // If a token is provided, it will be securely set using Dagger's
 // secret mechanism and used for authentication during the clone operation.
-func (m *{{.module_name}}) CloneGitRepo(
+func (m *{{.module_name}}) CloneGitRepoHTTPS(
 	// repoURL is the URL of the git repo to clone.
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
@@ -62,14 +69,38 @@ func (m *{{.module_name}}) CloneGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *dagger.Directory {
 	// Default to GitHub if no VCS is specified.
 	if vcs == "" {
 		vcs = "github"
 	}
 
+	gitCloneOpts := dagger.GitOpts{}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
 	// Initialize the Git clone request.
-	gitCloneRequest := dag.Git(repoURL)
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
 
 	// If a token is provided, set it as a secret and attach it to the clone request.
 	if token != nil {
@@ -78,10 +109,106 @@ func (m *{{.module_name}}) CloneGitRepo(
 				SetSecret(m.getTokenNameByVcs(vcs), m.getTokenValueBySecret(token)))
 	}
 
-	// Perform the Git clone operation and return the resulting directory.
-	return gitCloneRequest.
-		Head().
-		Tree()
+	if authHeader != nil {
+		gitCloneRequest = gitCloneRequest.
+			WithAuthHeader(authHeader)
+	}
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.
+			Directory(returnDir)
+	}
+
+	return repoContent
+}
+
+// CloneGitRepoSSH clones a git repository using SSH for authentication.
+// It allows specifying various options such as the branch, tag, or commit to checkout,
+// whether to keep the .git directory, and the directory path of the repository to return.
+//
+// Parameters:
+//
+//	repoURL: The URL of the git repo to clone.
+//	sshSocket: The SSH socket to use for authentication.
+//	sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//	returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//	branch: The branch to checkout. Optional parameter.
+//	keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//	tag: The tag to checkout. Optional parameter.
+//	commit: The commit to checkout. Optional parameter.
+//
+// Returns:
+//
+//	*dagger.Directory: The directory of the cloned repository.
+func (m *{{.module_name}}) CloneGitRepoSSH(
+	// repoURL is the URL of the git repo to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *dagger.Directory {
+	gitCloneOpts := dagger.GitOpts{
+		SSHAuthSocket: sshAuthSocket,
+	}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
+	if sshKnownHosts != "" {
+		gitCloneOpts.SSHKnownHosts = sshKnownHosts
+	}
+
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.Directory(returnDir)
+	}
+
+	return repoContent
 }
 
 // getTokenNameByVcs returns the appropriate token name based on the VCS type.

--- a/.daggerx/templates/mod-full/module/vcs.go.tmpl
+++ b/.daggerx/templates/mod-full/module/vcs.go.tmpl
@@ -7,6 +7,10 @@ import (
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/internal/dagger"
 )
 
+const (
+	netRcRootPath = "/root/.netrc"
+)
+
 // WithNewNetrcFileGitHub creates a new .netrc file with the GitHub credentials.
 //
 // The .netrc file is created in the root directory of the container.

--- a/.daggerx/templates/mod-full/tests/apis.go.tmpl
+++ b/.daggerx/templates/mod-full/tests/apis.go.tmpl
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 // TestWithContainer tests if the container is set correctly.
@@ -286,14 +288,14 @@ func (m *Tests) TestWithDownloadedFile(ctx context.Context) error {
 	return nil
 }
 
-// TestWithClonedGitRepo tests the WithClonedGitRepo function.
-func (m *Tests) TestWithClonedGitRepo(ctx context.Context) error {
+// TestWithClonedGitRepoHTTPS tests the WithClonedGitRepoHTTPS function.
+func (m *Tests) TestWithClonedGitRepoHTTPS(ctx context.Context) error {
 	targetModule := dag.{{.module_name}}()
 
 	// This is a public repository, the token isn't required.
 	targetModule = targetModule.
-		WithClonedGitRepo("https://github.com/excoriate/daggerverse",
-			dagger.{{.module_name}}WithClonedGitRepoOpts{})
+		WithClonedGitRepoHTTPS("https://github.com/excoriate/daggerverse",
+			dagger.{{.module_name}}WithClonedGitRepoHTTPSOpts{})
 
 	out, err := targetModule.Ctr().
 		WithExec([]string{"ls", "-l"}).
@@ -345,6 +347,193 @@ func (m *Tests) TestWithCacheBuster(ctx context.Context) error {
 	// Check if the cache-busting environment variable is set
 	if !strings.Contains(out, "CACHE_BUSTER") {
 		return WrapErrorf(err, "expected CACHE_BUSTER to be set, got %s", out)
+	}
+
+	return nil
+}
+
+// TestWithConfigFile tests the setting of a configuration file within the target module's container.
+//
+// This method mounts a configuration file (`common/test-file.yml`) into the target module's container
+// and verifies if it is correctly mounted by running the `cat` command within the container. It also
+// checks if the environment variable `TEST_CONFIG_PATH` is set to the correct path of the configuration file.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue mounting the configuration file, executing commands
+//     in the container, or if the configuration file or environment variable is not found in the output.
+func (m *Tests) TestWithConfigFile(ctx context.Context) error {
+	configTestFilePath := "common/test-file.yml"
+	configTestFilePathInCtr := filepath.Join(fixtures.MntPrefix, configTestFilePath)
+
+	file := m.getTestDir().
+		File(configTestFilePath)
+
+	targetModule := dag.
+		{{.module_name}}().
+		WithConfigFile(file, dagger.{{.module_name}}WithConfigFileOpts{
+			CfgPathInCtr: configTestFilePathInCtr,
+			SetEnvVar:    "TEST_CONFIG_PATH",
+		})
+
+	// Inspecting the file mounted into the container.
+	catOut, catOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"cat", configTestFilePathInCtr}).
+		Stdout(ctx)
+
+	if catOutErr != nil {
+		return WrapErrorf(catOutErr, "failed to cat the file %s", configTestFilePathInCtr)
+	}
+
+	if catOut == "" {
+		return WrapError(catOutErr, "expected to have at least one folder, got empty output")
+	}
+
+	if !strings.Contains(catOut, "users") {
+		return WrapErrorf(catOutErr, "expected to have at least one folder, got %s", catOut)
+	}
+
+	// Inspect if the environment variable was set, and it was the expected value.
+	envVarOut, envVarOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"printenv"}).
+		Stdout(ctx)
+
+	if envVarOutErr != nil {
+		return WrapError(envVarOutErr, "failed to get env vars")
+	}
+
+	if !strings.Contains(envVarOut, "TEST_CONFIG_PATH") {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	if !strings.Contains(envVarOut, configTestFilePathInCtr) {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	return nil
+}
+
+// TestWithUserAsOwnerOfDirs tests if the specified user and group own the created directories.
+func (m *Tests) TestWithUserAsOwnerOfDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: alpineCtr,
+		})
+
+	// Set ownership of directories to the specified user and group
+	targetModule = targetModule.
+		WithUserAsOwnerOfDirs("me", listOfDirsToOwn,
+			dagger.{{.module_name}}WithUserAsOwnerOfDirsOpts{
+				Group:           "mygroup",
+				ConfigureAsRoot: true,
+			})
+
+	// Verify ownership of the directories
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%U %G %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	// Check if the ownership is as expected
+	for _, dir := range listOfDirsToOwn {
+		expected := "me mygroup " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err,
+				"expected user owner to be me and group owner to be mygroup for %s, got %s", dir, out)
+		}
+	}
+
+	return nil
+}
+
+// TestWithUserWithPermissionsOnDirs tests if the specified permissions are set on the created directories.
+func (m *Tests) TestWithUserWithPermissionsOnDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: alpineCtr,
+		})
+
+	// Set permissions on directories
+	targetModule = targetModule.
+		WithUserWithPermissionsOnDirs("testuser", "0755", listOfDirsToOwn)
+
+	// Verify permissions
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%a %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	for _, dir := range listOfDirsToOwn {
+		expected := "755 " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err, "expected permissions to be 755 for %s, got %s", dir, out)
+		}
 	}
 
 	return nil

--- a/.daggerx/templates/mod-full/tests/main.go.tmpl
+++ b/.daggerx/templates/mod-full/tests/main.go.tmpl
@@ -80,8 +80,12 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithSecretAsEnvVar)
 	polTests.Go(m.TestWithDownloadedFile)
-	polTests.Go(m.TestWithClonedGitRepo)
+	polTests.Go(m.TestWithClonedGitRepoHTTPS)
 	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithConfigFile)
+	polTests.Go(m.TestWithUserAsOwnerOfDirs)
+	polTests.Go(m.TestWithUserWithPermissionsOnDirs)
 	// Test installation APIs
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
 	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
@@ -237,7 +241,7 @@ func (m *Tests) TestCloneGitRepo(ctx context.Context) error {
 
 	// This is a public repository, the token isn't required.
 	clonedRepo := targetModule.
-		CloneGitRepo("https://github.com/excoriate/daggerverse")
+		CloneGitRepoHTTPS("https://github.com/excoriate/daggerverse")
 
 	// Mount it as a directory, and inspect if it contains .gitignore and LICENSE files.
 	ctr := targetModule.Ctr().

--- a/.daggerx/templates/mod-light/module/apis.go.tmpl
+++ b/.daggerx/templates/mod-light/module/apis.go.tmpl
@@ -163,7 +163,7 @@ func (m *{{.module_name}}) WithDownloadedFile(
 	return m
 }
 
-// WithClonedGitRepo clones a Git repository and mounts it as a directory in the container.
+// WithClonedGitRepoHTTPS clones a Git repository and mounts it as a directory in the container.
 //
 // This method downloads a Git repository and mounts it as a directory in the container. It supports optional
 // authentication tokens for private repositories and can handle both GitHub and GitLab repositories.
@@ -177,7 +177,7 @@ func (m *{{.module_name}}) WithDownloadedFile(
 //
 // Returns:
 //   - *{{.module_name}}: The updated {{.module_name}} with the cloned repository mounted in the container.
-func (m *{{.module_name}}) WithClonedGitRepo(
+func (m *{{.module_name}}) WithClonedGitRepoHTTPS(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
@@ -185,12 +185,77 @@ func (m *{{.module_name}}) WithClonedGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *{{.module_name}} {
 	// Call the helper function to clone the repository.
-	clonedRepo := m.CloneGitRepo(repoURL, token, vcs)
+	clonedRepo := m.CloneGitRepoHTTPS(repoURL, token, vcs, authHeader, returnDir, branch, keepGitDir, tag, commit)
 
 	// Mount the cloned repository as a directory inside the container.
 	m.Ctr = m.Ctr.WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
+
+	return m
+}
+
+// WithClonedGitRepoSSH clones a git repository using SSH for authentication.
+//
+// Parameters:
+//   - repoURL: The URL of the git repository to clone.
+//   - sshSocket: The SSH socket to use for authentication.
+//   - sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//   - returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//   - branch: The branch to checkout. Optional parameter.
+//   - keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//
+// Returns:
+//   - *{{.module_name}}: The updated {{.module_name}} with the cloned repository mounted in the container.
+func (m *{{.module_name}}) WithClonedGitRepoSSH(
+	// repoURL is the URL of the git repository to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return. Optional parameter.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *{{.module_name}} {
+	// Call the helper function to clone the repository.
+	clonedRepo := m.CloneGitRepoSSH(repoURL, sshAuthSocket, sshKnownHosts, returnDir, branch, keepGitDir, tag, commit)
+
+	// Mount the cloned repository as a directory inside the container.
+	m.Ctr = m.
+		Ctr.
+		WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
 
 	return m
 }
@@ -224,24 +289,26 @@ func (m *{{.module_name}}) WithCacheBuster() *{{.module_name}} {
 // Returns:
 //   - *{{.module_name}}: The updated {{.module_name}} with the config file mounted in the container.
 func (m *{{.module_name}}) WithConfigFile(
-	// cfgPath is the path where the config file will be mounted.
+	// cfgFile is the config file to be mounted.
+	cfgFile *dagger.File,
+	// cfgPathInCtr is the path where the config file will be mounted.
 	// +optional
-	cfgPath string,
+	cfgPathInCtr string,
 	// setEnvVar is a string that set an environment variable in the container with the config file path.
 	// +optional
 	setEnvVar string,
-	// cfgFile is the config file to be mounted.
-	cfgFile *dagger.File) *{{.module_name}} {
-	if cfgPath == "" {
-		cfgPath = fixtures.MntPrefix
+) *{{.module_name}} {
+	if cfgPathInCtr == "" {
+		cfgPathInCtr = fixtures.MntPrefix
 	}
 
 	m.Ctr = m.Ctr.
-		WithMountedFile(cfgPath, cfgFile)
+		WithMountedFile(cfgPathInCtr, cfgFile)
 
 	if setEnvVar != "" {
-		setEnvVar = strings.ToUpper(setEnvVar)
-		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, cfgPath)
+		setEnvVar = strings.ToUpper(strings.TrimSpace(setEnvVar))
+		setEnvVar = strings.ReplaceAll(setEnvVar, "\\", "")
+		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, strings.TrimSpace(cfgPathInCtr))
 	}
 
 	return m
@@ -261,6 +328,15 @@ func (m *{{.module_name}}) WithCachedDirectory(
 	// setEnvVarWithCacheDirValue is the value to set the cache directory in the container.
 	// +optional
 	setEnvVarWithCacheDirValue string,
+	// cacheSharingMode is the sharing mode of the cache volume.
+	// +optional
+	cacheSharingMode dagger.CacheSharingMode,
+	// cacheVolumeRootDir is the root directory of the cache volume.
+	// +optional
+	cacheVolumeRootDir *dagger.Directory,
+	// cacheVolumeOwner is the owner of the cache volume.
+	// +optional
+	cacheVolumeOwner string,
 ) *{{.module_name}} {
 	// Define the cache volume
 	cacheVolume := dag.CacheVolume(path)
@@ -271,9 +347,22 @@ func (m *{{.module_name}}) WithCachedDirectory(
 		mountPath = filepath.Join(fixtures.MntPrefix, path)
 	}
 
+	cacheMountOpts := dagger.ContainerWithMountedCacheOpts{}
+	if cacheVolumeRootDir != nil {
+		cacheMountOpts.Source = cacheVolumeRootDir
+	}
+
+	if cacheVolumeOwner != "" {
+		cacheMountOpts.Owner = cacheVolumeOwner
+	}
+
+	if cacheSharingMode != "" {
+		cacheMountOpts.Sharing = cacheSharingMode
+	}
+
 	// Mount the cache volume in the container
 	m.Ctr = m.Ctr.
-		WithMountedCache(mountPath, cacheVolume)
+		WithMountedCache(mountPath, cacheVolume, cacheMountOpts)
 
 	// Set the environment variable if provided
 	if setEnvVarWithCacheDirValue != "" {
@@ -281,6 +370,91 @@ func (m *{{.module_name}}) WithCachedDirectory(
 		m.Ctr = m.
 			Ctr.
 			WithEnvVariable(envVarName, mountPath)
+	}
+
+	return m
+}
+
+// WithUserAsOwnerOfDirs sets the specified user (and optionally group) as the owner
+// of the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chown" command
+// within the container to change the ownership of each directory to the specified user (and optionally group).
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - group: The group to set as the owner of the directories. This is an optional parameter.
+//   - dirs: A slice of strings representing the directories to set the owner of. Each directory path should be
+//     specified relative to the container's filesystem.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the ownership of the specified directories changed.
+func (m *{{.module_name}}) WithUserAsOwnerOfDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// dirs is the directories to set the owner of.
+	dirs []string,
+	// group is the group to set as the owner of the directories.
+	// +optional
+	group string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given user.
+	// +optional
+	configureAsRoot bool,
+) *{{.module_name}} {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		if group != "" {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user + ":" + group, dir})
+		} else {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user, dir})
+		}
+	}
+
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser(user)
+	}
+
+	return m
+}
+
+// WithUserWithPermissionsOnDirs sets the specified permissions on the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chmod" command
+// within the container to change the permissions of each directory to the specified mode.
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - mode: The permissions to set on the directories. This should be a valid mode string (e.g., "0777").
+//   - dirs: A slice of strings representing the directories to set the permissions of. Each directory path should be
+//     specified relative to the container's filesystem.
+//   - configureAsRoot: Whether to configure the directories as root, and then it'll use the given mode.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the permissions of the specified directories changed.
+func (m *{{.module_name}}) WithUserWithPermissionsOnDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// mode is the permissions to set on the directories.
+	mode string,
+	// dirs is the directories to set the permissions of.
+	dirs []string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given mode.
+	// +optional
+	configureAsRoot bool,
+) *{{.module_name}} {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		m.Ctr = m.Ctr.WithExec([]string{"chmod", "-R", mode, dir})
+	}
+
+	if configureAsRoot && user != "" {
+		m.Ctr = m.Ctr.WithUser(user)
 	}
 
 	return m

--- a/.daggerx/templates/mod-light/module/content.go.tmpl
+++ b/.daggerx/templates/mod-light/module/content.go.tmpl
@@ -39,7 +39,7 @@ func (m *{{.module_name}}) DownloadFile(
 	return fileDownloaded
 }
 
-// CloneGitRepo clones a Git repository into a Dagger Directory.
+// CloneGitRepoHTTPS clones a Git repository into a Dagger Directory.
 //
 // Parameters:
 //   - repoURL: The URL of the git repository to clone (e.g., "https://github.com/user/repo").
@@ -47,13 +47,20 @@ func (m *{{.module_name}}) DownloadFile(
 //     not provided, the repository will be cloned without authentication.
 //   - vcs: (Optional) The version control system (VCS) to use for
 //     authentication. Defaults to "github". Supported values are "github" and "gitlab".
+//   - authHeader: (Optional) The authentication header to use for authentication. If
+//     not provided, the repository will be cloned without authentication.
+//   - returnDir: (Optional) A string that indicates the directory path of the repository to return.
+//   - branch: (Optional) The branch to checkout. If not provided, the default branch will be checked out.
+//   - keepGitDir: (Optional) A boolean that indicates if the .git directory should be kept. Defaults to false.
+//   - tag: (Optional) The tag to checkout. If not provided, no tag will be checked out.
+//   - commit: (Optional) The commit to checkout. If not provided, the latest commit will be checked out.
 //
 // Returns:
 //   - *dagger.Directory: A directory object representing the cloned repository.
 //
 // If a token is provided, it will be securely set using Dagger's
 // secret mechanism and used for authentication during the clone operation.
-func (m *{{.module_name}}) CloneGitRepo(
+func (m *{{.module_name}}) CloneGitRepoHTTPS(
 	// repoURL is the URL of the git repo to clone.
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
@@ -62,14 +69,38 @@ func (m *{{.module_name}}) CloneGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *dagger.Directory {
 	// Default to GitHub if no VCS is specified.
 	if vcs == "" {
 		vcs = "github"
 	}
 
+	gitCloneOpts := dagger.GitOpts{}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
 	// Initialize the Git clone request.
-	gitCloneRequest := dag.Git(repoURL)
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
 
 	// If a token is provided, set it as a secret and attach it to the clone request.
 	if token != nil {
@@ -78,10 +109,106 @@ func (m *{{.module_name}}) CloneGitRepo(
 				SetSecret(m.getTokenNameByVcs(vcs), m.getTokenValueBySecret(token)))
 	}
 
-	// Perform the Git clone operation and return the resulting directory.
-	return gitCloneRequest.
-		Head().
-		Tree()
+	if authHeader != nil {
+		gitCloneRequest = gitCloneRequest.
+			WithAuthHeader(authHeader)
+	}
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.
+			Directory(returnDir)
+	}
+
+	return repoContent
+}
+
+// CloneGitRepoSSH clones a git repository using SSH for authentication.
+// It allows specifying various options such as the branch, tag, or commit to checkout,
+// whether to keep the .git directory, and the directory path of the repository to return.
+//
+// Parameters:
+//
+//	repoURL: The URL of the git repo to clone.
+//	sshSocket: The SSH socket to use for authentication.
+//	sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//	returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//	branch: The branch to checkout. Optional parameter.
+//	keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//	tag: The tag to checkout. Optional parameter.
+//	commit: The commit to checkout. Optional parameter.
+//
+// Returns:
+//
+//	*dagger.Directory: The directory of the cloned repository.
+func (m *{{.module_name}}) CloneGitRepoSSH(
+	// repoURL is the URL of the git repo to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *dagger.Directory {
+	gitCloneOpts := dagger.GitOpts{
+		SSHAuthSocket: sshAuthSocket,
+	}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
+	if sshKnownHosts != "" {
+		gitCloneOpts.SSHKnownHosts = sshKnownHosts
+	}
+
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.Directory(returnDir)
+	}
+
+	return repoContent
 }
 
 // getTokenNameByVcs returns the appropriate token name based on the VCS type.

--- a/.daggerx/templates/mod-light/tests/apis.go.tmpl
+++ b/.daggerx/templates/mod-light/tests/apis.go.tmpl
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/Excoriate/daggerverse/{{.module_name_pkg}}/tests/internal/dagger"
+	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 // TestWithContainer tests if the container is set correctly.
@@ -286,14 +288,14 @@ func (m *Tests) TestWithDownloadedFile(ctx context.Context) error {
 	return nil
 }
 
-// TestWithClonedGitRepo tests the WithClonedGitRepo function.
-func (m *Tests) TestWithClonedGitRepo(ctx context.Context) error {
+// TestWithClonedGitRepoHTTPS tests the WithClonedGitRepoHTTPS function.
+func (m *Tests) TestWithClonedGitRepoHTTPS(ctx context.Context) error {
 	targetModule := dag.{{.module_name}}()
 
 	// This is a public repository, the token isn't required.
 	targetModule = targetModule.
-		WithClonedGitRepo("https://github.com/excoriate/daggerverse",
-			dagger.{{.module_name}}WithClonedGitRepoOpts{})
+		WithClonedGitRepoHTTPS("https://github.com/excoriate/daggerverse",
+			dagger.{{.module_name}}WithClonedGitRepoHTTPSOpts{})
 
 	out, err := targetModule.Ctr().
 		WithExec([]string{"ls", "-l"}).
@@ -345,6 +347,193 @@ func (m *Tests) TestWithCacheBuster(ctx context.Context) error {
 	// Check if the cache-busting environment variable is set
 	if !strings.Contains(out, "CACHE_BUSTER") {
 		return WrapErrorf(err, "expected CACHE_BUSTER to be set, got %s", out)
+	}
+
+	return nil
+}
+
+// TestWithConfigFile tests the setting of a configuration file within the target module's container.
+//
+// This method mounts a configuration file (`common/test-file.yml`) into the target module's container
+// and verifies if it is correctly mounted by running the `cat` command within the container. It also
+// checks if the environment variable `TEST_CONFIG_PATH` is set to the correct path of the configuration file.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue mounting the configuration file, executing commands
+//     in the container, or if the configuration file or environment variable is not found in the output.
+func (m *Tests) TestWithConfigFile(ctx context.Context) error {
+	configTestFilePath := "common/test-file.yml"
+	configTestFilePathInCtr := filepath.Join(fixtures.MntPrefix, configTestFilePath)
+
+	file := m.getTestDir().
+		File(configTestFilePath)
+
+	targetModule := dag.
+		{{.module_name}}().
+		WithConfigFile(file, dagger.{{.module_name}}WithConfigFileOpts{
+			CfgPathInCtr: configTestFilePathInCtr,
+			SetEnvVar:    "TEST_CONFIG_PATH",
+		})
+
+	// Inspecting the file mounted into the container.
+	catOut, catOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"cat", configTestFilePathInCtr}).
+		Stdout(ctx)
+
+	if catOutErr != nil {
+		return WrapErrorf(catOutErr, "failed to cat the file %s", configTestFilePathInCtr)
+	}
+
+	if catOut == "" {
+		return WrapError(catOutErr, "expected to have at least one folder, got empty output")
+	}
+
+	if !strings.Contains(catOut, "users") {
+		return WrapErrorf(catOutErr, "expected to have at least one folder, got %s", catOut)
+	}
+
+	// Inspect if the environment variable was set, and it was the expected value.
+	envVarOut, envVarOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"printenv"}).
+		Stdout(ctx)
+
+	if envVarOutErr != nil {
+		return WrapError(envVarOutErr, "failed to get env vars")
+	}
+
+	if !strings.Contains(envVarOut, "TEST_CONFIG_PATH") {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	if !strings.Contains(envVarOut, configTestFilePathInCtr) {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	return nil
+}
+
+// TestWithUserAsOwnerOfDirs tests if the specified user and group own the created directories.
+func (m *Tests) TestWithUserAsOwnerOfDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: alpineCtr,
+		})
+
+	// Set ownership of directories to the specified user and group
+	targetModule = targetModule.
+		WithUserAsOwnerOfDirs("me", listOfDirsToOwn,
+			dagger.{{.module_name}}WithUserAsOwnerOfDirsOpts{
+				Group:           "mygroup",
+				ConfigureAsRoot: true,
+			})
+
+	// Verify ownership of the directories
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%U %G %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	// Check if the ownership is as expected
+	for _, dir := range listOfDirsToOwn {
+		expected := "me mygroup " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err,
+				"expected user owner to be me and group owner to be mygroup for %s, got %s", dir, out)
+		}
+	}
+
+	return nil
+}
+
+// TestWithUserWithPermissionsOnDirs tests if the specified permissions are set on the created directories.
+func (m *Tests) TestWithUserWithPermissionsOnDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		{{.module_name}}(dagger.{{.module_name}}Opts{
+			Ctr: alpineCtr,
+		})
+
+	// Set permissions on directories
+	targetModule = targetModule.
+		WithUserWithPermissionsOnDirs("testuser", "0755", listOfDirsToOwn)
+
+	// Verify permissions
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%a %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	for _, dir := range listOfDirsToOwn {
+		expected := "755 " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err, "expected permissions to be 755 for %s, got %s", dir, out)
+		}
 	}
 
 	return nil

--- a/.daggerx/templates/mod-light/tests/main.go.tmpl
+++ b/.daggerx/templates/mod-light/tests/main.go.tmpl
@@ -76,8 +76,11 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithSecretAsEnvVar)
 	polTests.Go(m.TestWithDownloadedFile)
-	polTests.Go(m.TestWithClonedGitRepo)
+	polTests.Go(m.TestWithClonedGitRepoHTTPS)
 	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithConfigFile)
+	polTests.Go(m.TestWithUserAsOwnerOfDirs)
+	polTests.Go(m.TestWithUserWithPermissionsOnDirs)
 	// Test installation APIs
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
 	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
@@ -133,7 +136,7 @@ func (m *Tests) TestCloneGitRepo(ctx context.Context) error {
 
 	// This is a public repository, the token isn't required.
 	clonedRepo := targetModule.
-		CloneGitRepo("https://github.com/excoriate/daggerverse")
+		CloneGitRepoHTTPS("https://github.com/excoriate/daggerverse")
 
 	// Mount it as a directory, and inspect if it contains .gitignore and LICENSE files.
 	ctr := targetModule.Ctr().

--- a/module-template-light/apis.go
+++ b/module-template-light/apis.go
@@ -163,7 +163,7 @@ func (m *ModuleTemplateLight) WithDownloadedFile(
 	return m
 }
 
-// WithClonedGitRepo clones a Git repository and mounts it as a directory in the container.
+// WithClonedGitRepoHTTPS clones a Git repository and mounts it as a directory in the container.
 //
 // This method downloads a Git repository and mounts it as a directory in the container. It supports optional
 // authentication tokens for private repositories and can handle both GitHub and GitLab repositories.
@@ -177,7 +177,7 @@ func (m *ModuleTemplateLight) WithDownloadedFile(
 //
 // Returns:
 //   - *ModuleTemplateLight: The updated ModuleTemplateLight with the cloned repository mounted in the container.
-func (m *ModuleTemplateLight) WithClonedGitRepo(
+func (m *ModuleTemplateLight) WithClonedGitRepoHTTPS(
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
 	// +optional
@@ -185,12 +185,77 @@ func (m *ModuleTemplateLight) WithClonedGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *ModuleTemplateLight {
 	// Call the helper function to clone the repository.
-	clonedRepo := m.CloneGitRepo(repoURL, token, vcs)
+	clonedRepo := m.CloneGitRepoHTTPS(repoURL, token, vcs, authHeader, returnDir, branch, keepGitDir, tag, commit)
 
 	// Mount the cloned repository as a directory inside the container.
 	m.Ctr = m.Ctr.WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
+
+	return m
+}
+
+// WithClonedGitRepoSSH clones a git repository using SSH for authentication.
+//
+// Parameters:
+//   - repoURL: The URL of the git repository to clone.
+//   - sshSocket: The SSH socket to use for authentication.
+//   - sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//   - returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//   - branch: The branch to checkout. Optional parameter.
+//   - keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//
+// Returns:
+//   - *ModuleTemplateLight: The updated ModuleTemplateLight with the cloned repository mounted in the container.
+func (m *ModuleTemplateLight) WithClonedGitRepoSSH(
+	// repoURL is the URL of the git repository to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return. Optional parameter.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *ModuleTemplateLight {
+	// Call the helper function to clone the repository.
+	clonedRepo := m.CloneGitRepoSSH(repoURL, sshAuthSocket, sshKnownHosts, returnDir, branch, keepGitDir, tag, commit)
+
+	// Mount the cloned repository as a directory inside the container.
+	m.Ctr = m.
+		Ctr.
+		WithMountedDirectory(fixtures.MntPrefix, clonedRepo)
 
 	return m
 }
@@ -224,24 +289,26 @@ func (m *ModuleTemplateLight) WithCacheBuster() *ModuleTemplateLight {
 // Returns:
 //   - *ModuleTemplateLight: The updated ModuleTemplateLight with the config file mounted in the container.
 func (m *ModuleTemplateLight) WithConfigFile(
-	// cfgPath is the path where the config file will be mounted.
+	// cfgFile is the config file to be mounted.
+	cfgFile *dagger.File,
+	// cfgPathInCtr is the path where the config file will be mounted.
 	// +optional
-	cfgPath string,
+	cfgPathInCtr string,
 	// setEnvVar is a string that set an environment variable in the container with the config file path.
 	// +optional
 	setEnvVar string,
-	// cfgFile is the config file to be mounted.
-	cfgFile *dagger.File) *ModuleTemplateLight {
-	if cfgPath == "" {
-		cfgPath = fixtures.MntPrefix
+) *ModuleTemplateLight {
+	if cfgPathInCtr == "" {
+		cfgPathInCtr = fixtures.MntPrefix
 	}
 
 	m.Ctr = m.Ctr.
-		WithMountedFile(cfgPath, cfgFile)
+		WithMountedFile(cfgPathInCtr, cfgFile)
 
 	if setEnvVar != "" {
-		setEnvVar = strings.ToUpper(setEnvVar)
-		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, cfgPath)
+		setEnvVar = strings.ToUpper(strings.TrimSpace(setEnvVar))
+		setEnvVar = strings.ReplaceAll(setEnvVar, "\\", "")
+		m.Ctr = m.Ctr.WithEnvVariable(setEnvVar, strings.TrimSpace(cfgPathInCtr))
 	}
 
 	return m
@@ -261,6 +328,15 @@ func (m *ModuleTemplateLight) WithCachedDirectory(
 	// setEnvVarWithCacheDirValue is the value to set the cache directory in the container.
 	// +optional
 	setEnvVarWithCacheDirValue string,
+	// cacheSharingMode is the sharing mode of the cache volume.
+	// +optional
+	cacheSharingMode dagger.CacheSharingMode,
+	// cacheVolumeRootDir is the root directory of the cache volume.
+	// +optional
+	cacheVolumeRootDir *dagger.Directory,
+	// cacheVolumeOwner is the owner of the cache volume.
+	// +optional
+	cacheVolumeOwner string,
 ) *ModuleTemplateLight {
 	// Define the cache volume
 	cacheVolume := dag.CacheVolume(path)
@@ -271,9 +347,22 @@ func (m *ModuleTemplateLight) WithCachedDirectory(
 		mountPath = filepath.Join(fixtures.MntPrefix, path)
 	}
 
+	cacheMountOpts := dagger.ContainerWithMountedCacheOpts{}
+	if cacheVolumeRootDir != nil {
+		cacheMountOpts.Source = cacheVolumeRootDir
+	}
+
+	if cacheVolumeOwner != "" {
+		cacheMountOpts.Owner = cacheVolumeOwner
+	}
+
+	if cacheSharingMode != "" {
+		cacheMountOpts.Sharing = cacheSharingMode
+	}
+
 	// Mount the cache volume in the container
 	m.Ctr = m.Ctr.
-		WithMountedCache(mountPath, cacheVolume)
+		WithMountedCache(mountPath, cacheVolume, cacheMountOpts)
 
 	// Set the environment variable if provided
 	if setEnvVarWithCacheDirValue != "" {
@@ -281,6 +370,91 @@ func (m *ModuleTemplateLight) WithCachedDirectory(
 		m.Ctr = m.
 			Ctr.
 			WithEnvVariable(envVarName, mountPath)
+	}
+
+	return m
+}
+
+// WithUserAsOwnerOfDirs sets the specified user (and optionally group) as the owner
+// of the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chown" command
+// within the container to change the ownership of each directory to the specified user (and optionally group).
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - group: The group to set as the owner of the directories. This is an optional parameter.
+//   - dirs: A slice of strings representing the directories to set the owner of. Each directory path should be
+//     specified relative to the container's filesystem.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the ownership of the specified directories changed.
+func (m *ModuleTemplateLight) WithUserAsOwnerOfDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// dirs is the directories to set the owner of.
+	dirs []string,
+	// group is the group to set as the owner of the directories.
+	// +optional
+	group string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given user.
+	// +optional
+	configureAsRoot bool,
+) *ModuleTemplateLight {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		if group != "" {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user + ":" + group, dir})
+		} else {
+			m.Ctr = m.Ctr.WithExec([]string{"chown", "-R", user, dir})
+		}
+	}
+
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser(user)
+	}
+
+	return m
+}
+
+// WithUserWithPermissionsOnDirs sets the specified permissions on the given directories within the container.
+//
+// This method iterates over the provided list of directories and executes the "chmod" command
+// within the container to change the permissions of each directory to the specified mode.
+//
+// Parameters:
+//   - user: The user to set as the owner of the directories. This should be a valid user within the container.
+//   - mode: The permissions to set on the directories. This should be a valid mode string (e.g., "0777").
+//   - dirs: A slice of strings representing the directories to set the permissions of. Each directory path should be
+//     specified relative to the container's filesystem.
+//   - configureAsRoot: Whether to configure the directories as root, and then it'll use the given mode.
+//
+// Returns:
+// - *Terragrunt: The updated Terragrunt instance with the permissions of the specified directories changed.
+func (m *ModuleTemplateLight) WithUserWithPermissionsOnDirs(
+	// user is the user to set as the owner of the directories.
+	user string,
+	// mode is the permissions to set on the directories.
+	mode string,
+	// dirs is the directories to set the permissions of.
+	dirs []string,
+	// configureAsRoot is whether to configure the directories as root, and then it'll use the given mode.
+	// +optional
+	configureAsRoot bool,
+) *ModuleTemplateLight {
+	if configureAsRoot {
+		m.Ctr = m.Ctr.WithUser("root")
+	}
+
+	for _, dir := range dirs {
+		m.Ctr = m.Ctr.WithExec([]string{"chmod", "-R", mode, dir})
+	}
+
+	if configureAsRoot && user != "" {
+		m.Ctr = m.Ctr.WithUser(user)
 	}
 
 	return m

--- a/module-template-light/content.go
+++ b/module-template-light/content.go
@@ -39,7 +39,7 @@ func (m *ModuleTemplateLight) DownloadFile(
 	return fileDownloaded
 }
 
-// CloneGitRepo clones a Git repository into a Dagger Directory.
+// CloneGitRepoHTTPS clones a Git repository into a Dagger Directory.
 //
 // Parameters:
 //   - repoURL: The URL of the git repository to clone (e.g., "https://github.com/user/repo").
@@ -47,13 +47,20 @@ func (m *ModuleTemplateLight) DownloadFile(
 //     not provided, the repository will be cloned without authentication.
 //   - vcs: (Optional) The version control system (VCS) to use for
 //     authentication. Defaults to "github". Supported values are "github" and "gitlab".
+//   - authHeader: (Optional) The authentication header to use for authentication. If
+//     not provided, the repository will be cloned without authentication.
+//   - returnDir: (Optional) A string that indicates the directory path of the repository to return.
+//   - branch: (Optional) The branch to checkout. If not provided, the default branch will be checked out.
+//   - keepGitDir: (Optional) A boolean that indicates if the .git directory should be kept. Defaults to false.
+//   - tag: (Optional) The tag to checkout. If not provided, no tag will be checked out.
+//   - commit: (Optional) The commit to checkout. If not provided, the latest commit will be checked out.
 //
 // Returns:
 //   - *dagger.Directory: A directory object representing the cloned repository.
 //
 // If a token is provided, it will be securely set using Dagger's
 // secret mechanism and used for authentication during the clone operation.
-func (m *ModuleTemplateLight) CloneGitRepo(
+func (m *ModuleTemplateLight) CloneGitRepoHTTPS(
 	// repoURL is the URL of the git repo to clone.
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
@@ -62,14 +69,38 @@ func (m *ModuleTemplateLight) CloneGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *dagger.Directory {
 	// Default to GitHub if no VCS is specified.
 	if vcs == "" {
 		vcs = "github"
 	}
 
+	gitCloneOpts := dagger.GitOpts{}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
 	// Initialize the Git clone request.
-	gitCloneRequest := dag.Git(repoURL)
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
 
 	// If a token is provided, set it as a secret and attach it to the clone request.
 	if token != nil {
@@ -78,10 +109,106 @@ func (m *ModuleTemplateLight) CloneGitRepo(
 				SetSecret(m.getTokenNameByVcs(vcs), m.getTokenValueBySecret(token)))
 	}
 
-	// Perform the Git clone operation and return the resulting directory.
-	return gitCloneRequest.
-		Head().
-		Tree()
+	if authHeader != nil {
+		gitCloneRequest = gitCloneRequest.
+			WithAuthHeader(authHeader)
+	}
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.
+			Directory(returnDir)
+	}
+
+	return repoContent
+}
+
+// CloneGitRepoSSH clones a git repository using SSH for authentication.
+// It allows specifying various options such as the branch, tag, or commit to checkout,
+// whether to keep the .git directory, and the directory path of the repository to return.
+//
+// Parameters:
+//
+//	repoURL: The URL of the git repo to clone.
+//	sshSocket: The SSH socket to use for authentication.
+//	sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//	returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//	branch: The branch to checkout. Optional parameter.
+//	keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//	tag: The tag to checkout. Optional parameter.
+//	commit: The commit to checkout. Optional parameter.
+//
+// Returns:
+//
+//	*dagger.Directory: The directory of the cloned repository.
+func (m *ModuleTemplateLight) CloneGitRepoSSH(
+	// repoURL is the URL of the git repo to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *dagger.Directory {
+	gitCloneOpts := dagger.GitOpts{
+		SSHAuthSocket: sshAuthSocket,
+	}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
+	if sshKnownHosts != "" {
+		gitCloneOpts.SSHKnownHosts = sshKnownHosts
+	}
+
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.Directory(returnDir)
+	}
+
+	return repoContent
 }
 
 // getTokenNameByVcs returns the appropriate token name based on the VCS type.

--- a/module-template-light/tests/apis.go
+++ b/module-template-light/tests/apis.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/Excoriate/daggerverse/module-template-light/tests/internal/dagger"
+	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 // TestWithContainer tests if the container is set correctly.
@@ -286,14 +288,14 @@ func (m *Tests) TestWithDownloadedFile(ctx context.Context) error {
 	return nil
 }
 
-// TestWithClonedGitRepo tests the WithClonedGitRepo function.
-func (m *Tests) TestWithClonedGitRepo(ctx context.Context) error {
+// TestWithClonedGitRepoHTTPS tests the WithClonedGitRepoHTTPS function.
+func (m *Tests) TestWithClonedGitRepoHTTPS(ctx context.Context) error {
 	targetModule := dag.ModuleTemplateLight()
 
 	// This is a public repository, the token isn't required.
 	targetModule = targetModule.
-		WithClonedGitRepo("https://github.com/excoriate/daggerverse",
-			dagger.ModuleTemplateLightWithClonedGitRepoOpts{})
+		WithClonedGitRepoHTTPS("https://github.com/excoriate/daggerverse",
+			dagger.ModuleTemplateLightWithClonedGitRepoHTTPSOpts{})
 
 	out, err := targetModule.Ctr().
 		WithExec([]string{"ls", "-l"}).
@@ -345,6 +347,193 @@ func (m *Tests) TestWithCacheBuster(ctx context.Context) error {
 	// Check if the cache-busting environment variable is set
 	if !strings.Contains(out, "CACHE_BUSTER") {
 		return WrapErrorf(err, "expected CACHE_BUSTER to be set, got %s", out)
+	}
+
+	return nil
+}
+
+// TestWithConfigFile tests the setting of a configuration file within the target module's container.
+//
+// This method mounts a configuration file (`common/test-file.yml`) into the target module's container
+// and verifies if it is correctly mounted by running the `cat` command within the container. It also
+// checks if the environment variable `TEST_CONFIG_PATH` is set to the correct path of the configuration file.
+//
+// Arguments:
+// - ctx (context.Context): The context for the test execution.
+//
+// Returns:
+//   - error: Returns an error if there is an issue mounting the configuration file, executing commands
+//     in the container, or if the configuration file or environment variable is not found in the output.
+func (m *Tests) TestWithConfigFile(ctx context.Context) error {
+	configTestFilePath := "common/test-file.yml"
+	configTestFilePathInCtr := filepath.Join(fixtures.MntPrefix, configTestFilePath)
+
+	file := m.getTestDir().
+		File(configTestFilePath)
+
+	targetModule := dag.
+		ModuleTemplateLight().
+		WithConfigFile(file, dagger.ModuleTemplateLightWithConfigFileOpts{
+			CfgPathInCtr: configTestFilePathInCtr,
+			SetEnvVar:    "TEST_CONFIG_PATH",
+		})
+
+	// Inspecting the file mounted into the container.
+	catOut, catOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"cat", configTestFilePathInCtr}).
+		Stdout(ctx)
+
+	if catOutErr != nil {
+		return WrapErrorf(catOutErr, "failed to cat the file %s", configTestFilePathInCtr)
+	}
+
+	if catOut == "" {
+		return WrapError(catOutErr, "expected to have at least one folder, got empty output")
+	}
+
+	if !strings.Contains(catOut, "users") {
+		return WrapErrorf(catOutErr, "expected to have at least one folder, got %s", catOut)
+	}
+
+	// Inspect if the environment variable was set, and it was the expected value.
+	envVarOut, envVarOutErr := targetModule.
+		Ctr().
+		WithExec([]string{"printenv"}).
+		Stdout(ctx)
+
+	if envVarOutErr != nil {
+		return WrapError(envVarOutErr, "failed to get env vars")
+	}
+
+	if !strings.Contains(envVarOut, "TEST_CONFIG_PATH") {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	if !strings.Contains(envVarOut, configTestFilePathInCtr) {
+		return WrapErrorf(envVarOutErr, "expected TEST_CONFIG_PATH to be set, got %s", envVarOut)
+	}
+
+	return nil
+}
+
+// TestWithUserAsOwnerOfDirs tests if the specified user and group own the created directories.
+func (m *Tests) TestWithUserAsOwnerOfDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		ModuleTemplateLight(dagger.ModuleTemplateLightOpts{
+			Ctr: alpineCtr,
+		})
+
+	// Set ownership of directories to the specified user and group
+	targetModule = targetModule.
+		WithUserAsOwnerOfDirs("me", listOfDirsToOwn,
+			dagger.ModuleTemplateLightWithUserAsOwnerOfDirsOpts{
+				Group:           "mygroup",
+				ConfigureAsRoot: true,
+			})
+
+	// Verify ownership of the directories
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%U %G %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	// Check if the ownership is as expected
+	for _, dir := range listOfDirsToOwn {
+		expected := "me mygroup " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err,
+				"expected user owner to be me and group owner to be mygroup for %s, got %s", dir, out)
+		}
+	}
+
+	return nil
+}
+
+// TestWithUserWithPermissionsOnDirs tests if the specified permissions are set on the created directories.
+func (m *Tests) TestWithUserWithPermissionsOnDirs(ctx context.Context) error {
+	// Create a new container from the alpine:latest image
+	alpineCtr := dag.
+		Container().
+		From("alpine:latest")
+
+	// Install shadow package, create a group and a user
+	alpineCtr = alpineCtr.
+		WithExec([]string{"apk", "add", "--no-cache", "shadow"}).
+		WithExec([]string{"groupadd", "mygroup"}).
+		WithExec([]string{"useradd", "-G", "mygroup", "me"})
+
+	// List of directories to be created and owned by the user
+	listOfDirsToOwn := []string{
+		"/mnt/test-dir",
+		"/mnt/test-dir-1",
+		"/mnt/test-dir-2",
+		"/mnt/test-dir-3",
+		"/mnt/test-dir-4",
+		"/mnt/test-dir-5",
+	}
+
+	// Create the directories
+	for _, dir := range listOfDirsToOwn {
+		alpineCtr = alpineCtr.
+			WithExec([]string{"mkdir", "-p", dir})
+	}
+
+	// Create a new module with the container
+	targetModule := dag.
+		ModuleTemplateLight(dagger.ModuleTemplateLightOpts{
+			Ctr: alpineCtr,
+		})
+
+	// Set permissions on directories
+	targetModule = targetModule.
+		WithUserWithPermissionsOnDirs("testuser", "0755", listOfDirsToOwn)
+
+	// Verify permissions
+	out, err := targetModule.Ctr().
+		WithExec(append([]string{"stat", "-c", "%a %n"}, listOfDirsToOwn...)).
+		Stdout(ctx)
+
+	if err != nil {
+		return WrapError(err, "failed to get stat output")
+	}
+
+	for _, dir := range listOfDirsToOwn {
+		expected := "755 " + dir
+		if !strings.Contains(out, expected) {
+			return WrapErrorf(err, "expected permissions to be 755 for %s, got %s", dir, out)
+		}
 	}
 
 	return nil

--- a/module-template-light/tests/go.mod
+++ b/module-template-light/tests/go.mod
@@ -4,6 +4,7 @@ go 1.23.1
 
 require (
 	github.com/99designs/gqlgen v0.17.54
+	github.com/Excoriate/daggerx v0.0.32
 	github.com/Khan/genqlient v0.7.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/vektah/gqlparser/v2 v2.5.17

--- a/module-template-light/tests/go.sum
+++ b/module-template-light/tests/go.sum
@@ -1,5 +1,7 @@
 github.com/99designs/gqlgen v0.17.54 h1:AsF49k/7RJlwA00RQYsYN0T8cQuaosnV/7G1dHC3Uh8=
 github.com/99designs/gqlgen v0.17.54/go.mod h1:77/+pVe6zlTsz++oUg2m8VLgzdUPHxjoAG3BxI5y8Rc=
+github.com/Excoriate/daggerx v0.0.32 h1:aDZ/wZH8Liwc3eGti0jUOa+6fiBGBOzP5rpBPuPGmn4=
+github.com/Excoriate/daggerx v0.0.32/go.mod h1:eUUEHbbGJ5seyQxPkW3NQtqSQWJzzOx7Fg1PHbeZ2To=
 github.com/Khan/genqlient v0.7.0 h1:GZ1meyRnzcDTK48EjqB8t3bcfYvHArCUUvgOwpz1D4w=
 github.com/Khan/genqlient v0.7.0/go.mod h1:HNyy3wZvuYwmW3Y7mkoQLZsa/R5n5yIRajS1kPBvSFM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/module-template-light/tests/main.go
+++ b/module-template-light/tests/main.go
@@ -76,8 +76,11 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithSecretAsEnvVar)
 	polTests.Go(m.TestWithDownloadedFile)
-	polTests.Go(m.TestWithClonedGitRepo)
+	polTests.Go(m.TestWithClonedGitRepoHTTPS)
 	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithConfigFile)
+	polTests.Go(m.TestWithUserAsOwnerOfDirs)
+	polTests.Go(m.TestWithUserWithPermissionsOnDirs)
 	// Test installation APIs
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
 	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
@@ -133,7 +136,7 @@ func (m *Tests) TestCloneGitRepo(ctx context.Context) error {
 
 	// This is a public repository, the token isn't required.
 	clonedRepo := targetModule.
-		CloneGitRepo("https://github.com/excoriate/daggerverse")
+		CloneGitRepoHTTPS("https://github.com/excoriate/daggerverse")
 
 	// Mount it as a directory, and inspect if it contains .gitignore and LICENSE files.
 	ctr := targetModule.Ctr().

--- a/module-template/content.go
+++ b/module-template/content.go
@@ -39,7 +39,7 @@ func (m *ModuleTemplate) DownloadFile(
 	return fileDownloaded
 }
 
-// CloneGitRepo clones a Git repository into a Dagger Directory.
+// CloneGitRepoHTTPS clones a Git repository into a Dagger Directory.
 //
 // Parameters:
 //   - repoURL: The URL of the git repository to clone (e.g., "https://github.com/user/repo").
@@ -47,13 +47,20 @@ func (m *ModuleTemplate) DownloadFile(
 //     not provided, the repository will be cloned without authentication.
 //   - vcs: (Optional) The version control system (VCS) to use for
 //     authentication. Defaults to "github". Supported values are "github" and "gitlab".
+//   - authHeader: (Optional) The authentication header to use for authentication. If
+//     not provided, the repository will be cloned without authentication.
+//   - returnDir: (Optional) A string that indicates the directory path of the repository to return.
+//   - branch: (Optional) The branch to checkout. If not provided, the default branch will be checked out.
+//   - keepGitDir: (Optional) A boolean that indicates if the .git directory should be kept. Defaults to false.
+//   - tag: (Optional) The tag to checkout. If not provided, no tag will be checked out.
+//   - commit: (Optional) The commit to checkout. If not provided, the latest commit will be checked out.
 //
 // Returns:
 //   - *dagger.Directory: A directory object representing the cloned repository.
 //
 // If a token is provided, it will be securely set using Dagger's
 // secret mechanism and used for authentication during the clone operation.
-func (m *ModuleTemplate) CloneGitRepo(
+func (m *ModuleTemplate) CloneGitRepoHTTPS(
 	// repoURL is the URL of the git repo to clone.
 	repoURL string,
 	// token is the VCS token to use for authentication. Optional parameter.
@@ -62,14 +69,38 @@ func (m *ModuleTemplate) CloneGitRepo(
 	// vcs is the VCS to use for authentication. Optional parameter.
 	// +optional
 	vcs string,
+	// authHeader is the authentication header to use for authentication. Optional parameter.
+	// +optional
+	authHeader *dagger.Secret,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
 ) *dagger.Directory {
 	// Default to GitHub if no VCS is specified.
 	if vcs == "" {
 		vcs = "github"
 	}
 
+	gitCloneOpts := dagger.GitOpts{}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
 	// Initialize the Git clone request.
-	gitCloneRequest := dag.Git(repoURL)
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
 
 	// If a token is provided, set it as a secret and attach it to the clone request.
 	if token != nil {
@@ -78,10 +109,106 @@ func (m *ModuleTemplate) CloneGitRepo(
 				SetSecret(m.getTokenNameByVcs(vcs), m.getTokenValueBySecret(token)))
 	}
 
-	// Perform the Git clone operation and return the resulting directory.
-	return gitCloneRequest.
-		Head().
-		Tree()
+	if authHeader != nil {
+		gitCloneRequest = gitCloneRequest.
+			WithAuthHeader(authHeader)
+	}
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.
+			Directory(returnDir)
+	}
+
+	return repoContent
+}
+
+// CloneGitRepoSSH clones a git repository using SSH for authentication.
+// It allows specifying various options such as the branch, tag, or commit to checkout,
+// whether to keep the .git directory, and the directory path of the repository to return.
+//
+// Parameters:
+//
+//	repoURL: The URL of the git repo to clone.
+//	sshSocket: The SSH socket to use for authentication.
+//	sshKnownHosts: The known hosts to use for authentication. Optional parameter.
+//	returnDir: A string that indicates the directory path of the repository to return. Optional parameter.
+//	branch: The branch to checkout. Optional parameter.
+//	keepGitDir: A boolean that indicates if the .git directory should be kept. Optional parameter.
+//	tag: The tag to checkout. Optional parameter.
+//	commit: The commit to checkout. Optional parameter.
+//
+// Returns:
+//
+//	*dagger.Directory: The directory of the cloned repository.
+func (m *ModuleTemplate) CloneGitRepoSSH(
+	// repoURL is the URL of the git repo to clone.
+	repoURL string,
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// sshKnownHosts is the known hosts to use for authentication. Optional parameter.
+	// +optional
+	sshKnownHosts string,
+	// returnDir is a string that indicates the directory path of the repository to return.
+	// +optional
+	returnDir string,
+	// branch is the branch to checkout. Optional parameter.
+	// +optional
+	branch string,
+	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// +optional
+	keepGitDir bool,
+	// tag is the tag to checkout. Optional parameter.
+	// +optional
+	tag string,
+	// commit is the commit to checkout. Optional parameter.
+	// +optional
+	commit string,
+) *dagger.Directory {
+	gitCloneOpts := dagger.GitOpts{
+		SSHAuthSocket: sshAuthSocket,
+	}
+
+	if keepGitDir {
+		gitCloneOpts.KeepGitDir = keepGitDir
+	}
+
+	if sshKnownHosts != "" {
+		gitCloneOpts.SSHKnownHosts = sshKnownHosts
+	}
+
+	gitCloneRequest := dag.Git(repoURL, gitCloneOpts)
+
+	var repoContent *dagger.Directory
+
+	switch {
+	case commit != "":
+		repoContent = gitCloneRequest.Commit(commit).Tree()
+	case tag != "":
+		repoContent = gitCloneRequest.Tag(tag).Tree()
+	case branch != "":
+		repoContent = gitCloneRequest.Branch(branch).Tree()
+	default:
+		repoContent = gitCloneRequest.Head().Tree()
+	}
+
+	if returnDir != "" {
+		return repoContent.Directory(returnDir)
+	}
+
+	return repoContent
 }
 
 // getTokenNameByVcs returns the appropriate token name based on the VCS type.

--- a/module-template/tests/go.mod
+++ b/module-template/tests/go.mod
@@ -4,6 +4,7 @@ go 1.22.5
 
 require (
 	github.com/99designs/gqlgen v0.17.49
+	github.com/Excoriate/daggerx v0.0.32
 	github.com/Khan/genqlient v0.7.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/vektah/gqlparser/v2 v2.5.16

--- a/module-template/tests/go.sum
+++ b/module-template/tests/go.sum
@@ -1,5 +1,7 @@
 github.com/99designs/gqlgen v0.17.49 h1:b3hNGexHd33fBSAd4NDT/c3NCcQzcAVkknhN9ym36YQ=
 github.com/99designs/gqlgen v0.17.49/go.mod h1:tC8YFVZMed81x7UJ7ORUwXF4Kn6SXuucFqQBhN8+BU0=
+github.com/Excoriate/daggerx v0.0.32 h1:aDZ/wZH8Liwc3eGti0jUOa+6fiBGBOzP5rpBPuPGmn4=
+github.com/Excoriate/daggerx v0.0.32/go.mod h1:eUUEHbbGJ5seyQxPkW3NQtqSQWJzzOx7Fg1PHbeZ2To=
 github.com/Khan/genqlient v0.7.0 h1:GZ1meyRnzcDTK48EjqB8t3bcfYvHArCUUvgOwpz1D4w=
 github.com/Khan/genqlient v0.7.0/go.mod h1:HNyy3wZvuYwmW3Y7mkoQLZsa/R5n5yIRajS1kPBvSFM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/module-template/tests/main.go
+++ b/module-template/tests/main.go
@@ -80,8 +80,12 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestWithEnvironmentVariable)
 	polTests.Go(m.TestWithSecretAsEnvVar)
 	polTests.Go(m.TestWithDownloadedFile)
-	polTests.Go(m.TestWithClonedGitRepo)
+	polTests.Go(m.TestWithClonedGitRepoHTTPS)
 	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithCacheBuster)
+	polTests.Go(m.TestWithConfigFile)
+	polTests.Go(m.TestWithUserAsOwnerOfDirs)
+	polTests.Go(m.TestWithUserWithPermissionsOnDirs)
 	// Test installation APIs
 	polTests.Go(m.TestWithUtilitiesInAlpineContainer)
 	polTests.Go(m.TestWithUtilitiesInUbuntuContainer)
@@ -237,7 +241,7 @@ func (m *Tests) TestCloneGitRepo(ctx context.Context) error {
 
 	// This is a public repository, the token isn't required.
 	clonedRepo := targetModule.
-		CloneGitRepo("https://github.com/excoriate/daggerverse")
+		CloneGitRepoHTTPS("https://github.com/excoriate/daggerverse")
 
 	// Mount it as a directory, and inspect if it contains .gitignore and LICENSE files.
 	ctr := targetModule.Ctr().

--- a/module-template/vcs.go
+++ b/module-template/vcs.go
@@ -7,6 +7,10 @@ import (
 	"github.com/Excoriate/daggerverse/module-template/internal/dagger"
 )
 
+const (
+	netRcRootPath = "/root/.netrc"
+)
+
 // WithNewNetrcFileGitHub creates a new .netrc file with the GitHub credentials.
 //
 // The .netrc file is created in the root directory of the container.


### PR DESCRIPTION
- Add new options to `WithCachedDirectory` method to allow setting cache volume source, owner, and sharing mode
- Update the container mount operation to use the new cache volume options

feat: Expand test coverage for module-light template
- Add new tests for `TestWithConfigFile`, `TestWithUserAsOwnerOfDirs`, and `TestWithUserWithPermissionsOnDirs`
- Update `TestWithClonedGitRepo` to use the new `TestWithClonedGitRepoHTTPS` method

feat: Enhance git cloning functionality in module-full template
- Add support for cloning a git repository using SSH authentication
- Expand the `CloneGitRepo` method to allow specifying branch, tag, or commit to checkout
- Return the directory of the cloned repository with an optional return directory path