### PR TITLE
feat: Improve module creation with Daggy

### DIFF
--- a/.daggerx/daggy/src/configuration.rs
+++ b/.daggerx/daggy/src/configuration.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 #[derive(Debug)]
 pub struct NewDaggerModule {
@@ -38,9 +38,23 @@ pub fn get_module_configurations(
 ) -> Result<NewDaggerModule, Error> {
     let module_path_full = env::current_dir()?.join(module);
     let current_root_dir = env::current_dir()?;
-    let template_path_by_type = current_root_dir
-        .join(TEMPLATE_DIR)
-        .join(format!("mod-{}", module_type));
+
+    if module_type != "light" && module_type != "full" {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Invalid module type. Please use 'light' or 'full'.",
+        ));
+    }
+
+    let template_path_by_type = if module_type == "light" {
+        current_root_dir
+            .join(TEMPLATE_DIR)
+            .join(MODULE_LIGHT_TEMPLATE_DIR)
+    } else {
+        current_root_dir
+            .join(TEMPLATE_DIR)
+            .join(MODULE_FULL_TEMPLATE_DIR)
+    };
 
     Ok(NewDaggerModule {
         path: module_path_full.to_string_lossy().to_string(),

--- a/justfile
+++ b/justfile
@@ -158,16 +158,18 @@ cilocal mod: (reloadall mod) (golint mod) (test mod) (examplesgo mod) (ci-module
   @echo "Running the whole CI locally... 🚀"
 
 # Recipe to create a new module using Daggy (a rust CLI tool)
-# Recipe to create a new module using Daggy (a rust CLI tool)
 create mod with-ci='false' type='full':
-  @echo "Creating a new {{type}} module..."
+  @echo "Creating a new {{type}} module of type {{type}}..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
   @if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
 
 # Recipe to create a new light module using Daggy
-createlight mod with-ci='false':
-  @just create {{mod}} with-ci={{with-ci}} type='light'
+createlight mod with-ci='false' type='light':
+  @echo "Creating a new {{type}} module of type {{type}}..."
+  @cd .daggerx/daggy && cargo build --release
+  @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
+  @if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
 
 # This recipe validate if the dagger module has the README.md file and the LICENSE file
 ci-module-docs mod:


### PR DESCRIPTION
- Add support for creating 'light' and 'full' module types
- Validate the module type input and return an error for invalid types
- Refactor the template path selection logic to handle both 'light' and 'full' module types
- Update the `createlight` just recipe to align with the new changes