### PR TITLE
feat: Add .cursorrules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Cargo.lock
 # AI
 .aider*
 AI/**.md
+.cursorrules


### PR DESCRIPTION
Adds the .cursorrules file to the .gitignore. This file is used to
configure the cursor behavior in the application and should not be
tracked in the repository.