### PR TITLE
feat: Add Dagger SDK flag to module development commands

### DIFF
--- a/.daggerx/daggy/src/git.rs
+++ b/.daggerx/daggy/src/git.rs
@@ -1,8 +1,14 @@
 use std::io::Error;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub fn find_git_root() -> Result<String, Error> {
+    find_git_root_from_path(&std::env::current_dir()?)
+}
+
+pub fn find_git_root_from_path(start_path: &Path) -> Result<String, Error> {
     let output = Command::new("git")
+        .current_dir(start_path)
         .args(&["rev-parse", "--show-toplevel"])
         .output()?;
 

--- a/.daggerx/daggy/src/git_test.rs
+++ b/.daggerx/daggy/src/git_test.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use crate::git;
+    use std::env;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_find_git_root() {
+        // Start from the current executable's directory and search upwards
+        let mut current_dir = env::current_exe().unwrap().parent().unwrap().to_path_buf();
+        
+        while current_dir.parent().is_some() {
+            if let Ok(git_root) = git::find_git_root_from_path(&current_dir) {
+                // We found a git root
+                assert!(Path::new(&git_root).is_absolute());
+                assert!(Path::new(&git_root).join(".git").exists());
+                return;
+            }
+            // Move up one directory
+            current_dir = current_dir.parent().unwrap().to_path_buf();
+        }
+        
+        panic!("No Git repository found in any parent directory");
+    }
+
+    #[test]
+    fn test_find_git_root_not_in_repo() {
+        // This test remains unchanged
+        let original_dir = env::current_dir().unwrap();
+        env::set_current_dir("/tmp").unwrap();
+
+        let result = git::find_git_root();
+        assert!(result.is_err());
+
+        env::set_current_dir(original_dir).unwrap();
+    }
+}

--- a/.daggerx/daggy/src/main.rs
+++ b/.daggerx/daggy/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod git_test;
+
 mod args;
 mod command_utils;
 mod configuration;
@@ -12,9 +15,6 @@ mod templating;
 mod utils;
 mod cmd_create_module;
 mod cmd_develop_modules;
-
-#[cfg(test)]
-mod git_test;
 
 use args::Args;
 use clap::Parser;
@@ -38,7 +38,7 @@ fn main() -> Result<(), Error> {
 fn create_module_task(args: &Args) -> Result<(), Error> {
     match &args.module {
         Some(module) => {
-            cmd_create_module::create_module(module, &args.module_type)
+            cmd_create_module::create_module(module, args.module_type.as_deref().unwrap_or("full"))
         }
         None => {
             eprintln!("Module name is required for 'create' task");

--- a/justfile
+++ b/justfile
@@ -40,39 +40,39 @@ precommit:
 dc mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger module..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger call {{args}}
+  echo "🚀 Running Dagger module..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}} && dagger call {{args}}
 
 # Recipe to run Dagger module tests 🧪
 dct mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger module tests..."
-  @echo "Currently in {{mod}} module 🧪, path=`pwd`"
-  @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger call {{args}}
+  echo "🧪 Running Dagger module tests..."
+  echo "🧪 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}}/tests || (echo "❌ Module not found" && exit 1)
+  cd {{mod}}/tests && dagger call {{args}}
 
 # Recipe to run Dagger module examples 📄
 dce mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger module examples ... 📄"
-  @echo "Currently in {{mod}} module 🧪, path=`pwd`"
-  @test -d {{mod}}/examples/go || (echo "Module examples not found" && exit 1)
-  @cd {{mod}}/examples/go && dagger call {{args}}
+  echo "📄 Running Dagger module examples ..."
+  echo "🧪 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}}/examples/go || (echo "❌ Module examples not found" && exit 1)
+  cd {{mod}}/examples/go && dagger call {{args}}
 
 # Recipe to bump version of a module 🔄
 bump-version mod bump='minor':
     #!/usr/bin/env bash
     set -euo pipefail
 
-    echo "Bumping version for {{mod}} module"
+    echo "🔄 Bumping version for {{mod}} module"
 
     # Verify that the module directory exists and contains a dagger.json file
     if [ ! -d "{{mod}}" ] || [ ! -f "{{mod}}/dagger.json" ]; then
-        echo "Module {{mod}} not found or dagger.json missing"
+        echo "❌ Module {{mod}} not found or dagger.json missing"
         exit 1
     fi
 
@@ -98,161 +98,164 @@ bump-version mod bump='minor':
     git tag -a "$new_tag" -m "Bump {{mod}} to $new_version"
     git push origin "$new_tag"
 
-    echo "Version bumped to $new_version and tag $new_tag created"
-    echo "Tag has been pushed to the remote repository"
+    echo "✅ Version bumped to $new_version and tag $new_tag created"
+    echo "🚀 Tag has been pushed to the remote repository"
 
 # Recipe to reload Dagger module (Dagger Develop) 🔄
 reloadmod mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger development in a given module..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @if ! docker info > /dev/null 2>&1; then \
-    echo "Docker is not running. Please start Docker and try again."; \
-    exit 1; \
+  echo "🚀 Running Dagger development in a given module..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  if ! docker info > /dev/null 2>&1; then
+    echo "❌ Docker is not running. Please start Docker and try again."
+    exit 1
   fi
-  # @cd {{mod}} && dagger develop {{args}}
-  @cd {{mod}} && dagger develop {{args}}
-  @echo "Module reloaded successfully ✅"
+  cd {{mod}} && dagger develop {{args}}
+  echo "✅ Module reloaded successfully"
 
 # Recipe to reload a Dagger module's tests (Dagger Develop) 🔄
 reloadtest mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger development in a given module's tests..."
-  @echo "Currently in {{mod}}/tests module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger develop {{args}}
-  @echo "Module Tests reloaded successfully ✅"
+  echo "🚀 Running Dagger development in a given module's tests..."
+  echo "📦 Currently in {{mod}}/tests module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}}/tests && dagger develop {{args}}
+  echo "✅ Module Tests reloaded successfully"
 
 # Recipe to reload Dagger module and its underlying tests (Dagger Develop & Dagger Call/Functions) 🔄
 reloadall mod *args:
   #!/usr/bin/env sh
   set -e
-  echo "Reloading Dagger module and also the tests..."
-  echo "Currently in {{mod}} module 🔄, path=`pwd`"
-  test -d {{mod}} || (echo "Module not found" && exit 1)
+  echo "🔄 Reloading Dagger module and also the tests..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
   cd {{mod}} && dagger develop {{args}}
   cd tests && dagger develop {{args}}
   cd ../examples/go && dagger develop {{args}}
-  echo "Module reloaded successfully 🚀"
-  echo "Inspecting the module... 🕵️"
+  echo "🚀 Module reloaded successfully"
+  echo "🕵️ Inspecting the module..."
   cd .. && dagger call && dagger functions
 
 # Recipe to run all the tests in the target module 🧪
 test mod *args: (reloadmod mod) (reloadtest mod)
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger module tests..."
-  @echo "Currently in {{mod}} module 🧪, path=`pwd`"
-  @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger functions
-  @cd {{mod}}/tests && dagger call test-all {{args}}
+  echo "🚀 Running Dagger module tests..."
+  echo "📦 Currently in {{mod}} module 🧪, path=`pwd`"
+  test -d {{mod}}/tests || (echo "❌ Module not found" && exit 1)
+  cd {{mod}}/tests && dagger functions
+  cd {{mod}}/tests && dagger call test-all {{args}}
 
 # Recipe to run all the examples in the target module 📄
 examplesgo mod *args: (reloadmod mod)
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger module examples (Go SDK)..."
-  @echo "Currently in {{mod}} module 🧪, path=`pwd`"
-  @test -d {{mod}}/examples/go || (echo "Module examples not found" && exit 1)
-  @cd {{mod}}/examples/go && dagger call all-recipes {{args}}
+  echo "🚀 Running Dagger module examples (Go SDK)..."
+  echo "📦 Currently in {{mod}} module 🧪, path=`pwd`"
+  test -d {{mod}}/examples/go || (echo "❌ Module examples not found" && exit 1)
+  cd {{mod}}/examples/go && dagger call all-recipes {{args}}
 
 # Recipe to run GolangCI Lint 🧹
 golint mod *args:
-  @echo "Running Go (GolangCI)... 🧹 "
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @echo "Currently in {{mod}} module 📦, path=`pwd`/{{mod}}"
-  @cd ./{{mod}} && nix-shell -p golangci-lint --run "golangci-lint run --config ../.golangci.yml {{args}}"
-  @echo "Checking now the tests 🧪 project ..."
-  @cd ./{{mod}}/tests && nix-shell -p golangci-lint --run "golangci-lint run --config ../../.golangci.yml {{args}}"
-  @echo "Checking now the examples 📄 project ..."
-  @cd ./{{mod}}/examples/go && nix-shell -p golangci-lint --run "golangci-lint run --config ../../../.golangci.yml {{args}}"
+  #!/usr/bin/env sh
+  set -e
+  echo "Running Go (GolangCI)... 🧹 "
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  echo "📦 Currently in {{mod}} module, path=`pwd`/{{mod}}"
+  cd ./{{mod}} && nix-shell -p golangci-lint --run "golangci-lint run --config ../.golangci.yml {{args}}"
+  echo "🧪 Checking now the tests project ..."
+  cd ./{{mod}}/tests && nix-shell -p golangci-lint --run "golangci-lint run --config ../../.golangci.yml {{args}}"
+  echo "📄 Checking now the examples project ..."
+  cd ./{{mod}}/examples/go && nix-shell -p golangci-lint --run "golangci-lint run --config ../../../.golangci.yml {{args}}"
 
 # Recipe to run the whole CI locally 🚀
 cilocal mod: (reloadall mod) (golint mod) (test mod) (examplesgo mod) (ci-module-docs mod)
-  @echo "Running the whole CI locally... 🚀"
+  #!/usr/bin/env sh
+  set -e
+  echo "🚀 Running the whole CI locally... 🚀"
 
 # Recipe to create a new module using Daggy (a rust CLI tool) 🛠️
 create mod with-ci='false' type='full':
   #!/usr/bin/env sh
   set -e
-  @echo "Creating a new {{type}} module of type {{type}}..."
-  @cd .daggerx/daggy && cargo build --release
-  @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
-  @if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
+  echo "🚀 Creating a new {{type}} module of type {{type}}..."
+  cd .daggerx/daggy && cargo build --release
+  .daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
+  if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
 
 # Recipe to create a new light module using Daggy 🛠️
 createlight mod with-ci='false' type='light':
-  @echo "Creating a new {{type}} module of type {{type}}..."
-  @cd .daggerx/daggy && cargo build --release
-  @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
-  @if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
+  #!/usr/bin/env sh
+  set -e
+  echo "🚀 Creating a new {{type}} module of type {{type}}..."
+  cd .daggerx/daggy && cargo build --release
+  .daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
+  if [ "{{with-ci}}" = "true" ]; then just cilocal {{mod}}; fi
 
 # Recipe to validate if the dagger module has the README.md file and the LICENSE file 📄
 ci-module-docs mod:
   #!/usr/bin/env sh
   set -e
-  @echo "Validating the module documentation..."
-  @test -f {{mod}}/README.md || (echo "README.md file not found" && exit 1)
-  @test -f {{mod}}/LICENSE || (echo "LICENSE file not found" && exit 1)
-  @echo "Module documentation is valid ✅"
+  echo "🔍 Validating the module documentation..."
+  test -f {{mod}}/README.md || (echo "❌ README.md file not found" && exit 1)
+  test -f {{mod}}/LICENSE || (echo "❌ LICENSE file not found" && exit 1)
+  echo "✅ Module documentation is valid"
 
 # Recipe for dagger call 📞
 call mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger call..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger call {{args}}
+  echo "🚀 Running Dagger call..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}} && dagger call {{args}}
 
 # Recipe for dagger call tests in a certain module 🧪
 calltests mod *args: (reloadtest mod)
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger call tests..."
-  @echo "Currently in {{mod}} module 🧪, path=`pwd`"
-  @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger functions
-  @cd {{mod}}/tests && dagger call {{args}}
-
+  echo "🚀 Running Dagger call tests..."
+  echo "🧪 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}}/tests || (echo "❌ Module not found" && exit 1)
+  cd {{mod}}/tests && dagger functions
+  cd {{mod}}/tests && dagger call {{args}}
 # Recipe to run dagger develop in all modules 🔄
 develop-all:
   #!/usr/bin/env sh
   set -e
-  @echo "Developing all Dagger modules..."
-  @cd .daggerx/daggy && cargo build --release
-  @.daggerx/daggy/target/release/daggy --task=develop
+  echo "🚀 Developing (or upgrading) all Dagger modules..."
+  cd .daggerx/daggy && cargo build --release
+  .daggerx/daggy/target/release/daggy --task=develop
 
 # Recipe that wraps the dagger CLI in a certain module 📦
 dag mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Running Dagger CLI in a certain module..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger {{args}}
+  echo "🚀 Running Dagger CLI in a certain module..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}} && dagger {{args}}
 
 # Recipe to call a certain function by a module's name, passing extra arguments optionally 📞
 callfn mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Calling a function in a certain module..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger functions
-  @cd {{mod}} && dagger call {{args}}
-
+  echo "🔧 Calling a function in a certain module..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}} && dagger functions
+  cd {{mod}} && dagger call {{args}}
 # Recipe to list functions in a certain module 📄
 listfns mod *args:
   #!/usr/bin/env sh
   set -e
-  @echo "Listing functions in a certain module..."
-  @echo "Currently in {{mod}} module 📦, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger functions
+  echo "📄 Listing functions in a certain module..."
+  echo "📦 Currently in {{mod}} module, path=`pwd`"
+  test -d {{mod}} || (echo "❌ Module not found" && exit 1)
+  cd {{mod}} && dagger functions
 
 # Recipe to run Daggy tests 🧪
 daggy-tests:

--- a/justfile
+++ b/justfile
@@ -83,13 +83,13 @@ bump-version mod bump='minor':
     # Calculate the new version
     new_version="v$(semver bump {{bump}} "v$current_version")"
 
-    echo "Current version: v$current_version"
-    echo "New version: $new_version"
+    echo "🔢 Current version: v$current_version"
+    echo "🆕 New version: $new_version"
 
     read -p "Proceed with version bump? (y/N) " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Aborting"
+        echo "❌ Aborting"
         exit 1
     fi
 

--- a/justfile
+++ b/justfile
@@ -260,4 +260,5 @@ listfns mod *args:
 # Recipe to run Daggy tests 🧪
 daggy-tests:
   @echo "Running Daggy tests 🧪 ..."
+  @cd .daggerx/daggy && cargo build --release
   @cd .daggerx/daggy && cargo test

--- a/justfile
+++ b/justfile
@@ -38,6 +38,8 @@ precommit:
 
 # Recipe to run Dagger module 📦
 dc mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -45,6 +47,8 @@ dc mod *args:
 
 # Recipe to run Dagger module tests 🧪
 dct mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger module tests..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
@@ -52,6 +56,8 @@ dct mod *args:
 
 # Recipe to run Dagger module examples 📄
 dce mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger module examples ... 📄"
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/examples/go || (echo "Module examples not found" && exit 1)
@@ -97,6 +103,8 @@ bump-version mod bump='minor':
 
 # Recipe to reload Dagger module (Dagger Develop) 🔄
 reloadmod mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger development in a given module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -117,18 +125,22 @@ reloadtest mod *args:
 
 # Recipe to reload Dagger module and its underlying tests (Dagger Develop & Dagger Call/Functions) 🔄
 reloadall mod *args:
-  @echo "Reloading Dagger module and also the tests..."
-  @echo "Currently in {{mod}} module 🔄, path=`pwd`"
-  @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger develop {{args}}
-  @cd {{mod}}/tests && dagger develop {{args}}
-  @cd {{mod}}/examples/go && dagger develop {{args}}
-  @echo "Module reloaded successfully 🚀"
-  @echo "Inspecting the module... 🕵️"
-  @cd {{mod}} && dagger call && dagger functions
+  #!/usr/bin/env sh
+  set -e
+  echo "Reloading Dagger module and also the tests..."
+  echo "Currently in {{mod}} module 🔄, path=`pwd`"
+  test -d {{mod}} || (echo "Module not found" && exit 1)
+  cd {{mod}} && dagger develop {{args}}
+  cd tests && dagger develop {{args}}
+  cd ../examples/go && dagger develop {{args}}
+  echo "Module reloaded successfully 🚀"
+  echo "Inspecting the module... 🕵️"
+  cd .. && dagger call && dagger functions
 
 # Recipe to run all the tests in the target module 🧪
 test mod *args: (reloadmod mod) (reloadtest mod)
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger module tests..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
@@ -137,6 +149,8 @@ test mod *args: (reloadmod mod) (reloadtest mod)
 
 # Recipe to run all the examples in the target module 📄
 examplesgo mod *args: (reloadmod mod)
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger module examples (Go SDK)..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/examples/go || (echo "Module examples not found" && exit 1)
@@ -144,6 +158,8 @@ examplesgo mod *args: (reloadmod mod)
 
 # Recipe to run GolangCI Lint 🧹
 golint mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Go (GolangCI)... 🧹 "
   @test -d {{mod}} || (echo "Module not found" && exit 1)
   @echo "Currently in {{mod}} module 📦, path=`pwd`/{{mod}}"
@@ -159,6 +175,8 @@ cilocal mod: (reloadall mod) (golint mod) (test mod) (examplesgo mod) (ci-module
 
 # Recipe to create a new module using Daggy (a rust CLI tool) 🛠️
 create mod with-ci='false' type='full':
+  #!/usr/bin/env sh
+  set -e
   @echo "Creating a new {{type}} module of type {{type}}..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
@@ -166,6 +184,8 @@ create mod with-ci='false' type='full':
 
 # Recipe to create a new light module using Daggy 🛠️
 createlight mod with-ci='false' type='light':
+  #!/usr/bin/env sh
+  set -e
   @echo "Creating a new {{type}} module of type {{type}}..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}
@@ -173,6 +193,8 @@ createlight mod with-ci='false' type='light':
 
 # Recipe to validate if the dagger module has the README.md file and the LICENSE file 📄
 ci-module-docs mod:
+  #!/usr/bin/env sh
+  set -e
   @echo "Validating the module documentation..."
   @test -f {{mod}}/README.md || (echo "README.md file not found" && exit 1)
   @test -f {{mod}}/LICENSE || (echo "LICENSE file not found" && exit 1)
@@ -180,6 +202,8 @@ ci-module-docs mod:
 
 # Recipe for dagger call 📞
 call mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger call..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -187,20 +211,26 @@ call mod *args:
 
 # Recipe for dagger call tests in a certain module 🧪
 calltests mod *args: (reloadtest mod)
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger call tests..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger functions {{args}}
+  @cd {{mod}}/tests && dagger functions
   @cd {{mod}}/tests && dagger call {{args}}
 
 # Recipe to run dagger develop in all modules 🔄
 develop-all:
+  #!/usr/bin/env sh
+  set -e
   @echo "Developing all Dagger modules..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=develop
 
 # Recipe that wraps the dagger CLI in a certain module 📦
 dag mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger CLI in a certain module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -208,6 +238,8 @@ dag mod *args:
 
 # Recipe to call a certain function by a module's name, passing extra arguments optionally 📞
 callfn mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Calling a function in a certain module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -216,6 +248,8 @@ callfn mod *args:
 
 # Recipe to list functions in a certain module 📄
 listfns mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Listing functions in a certain module..."
   @echo "Currently in {{mod}} module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -223,5 +257,7 @@ listfns mod *args:
 
 # Recipe to run Daggy tests 🧪
 daggy-tests:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Daggy tests 🧪 ..."
   @cd .daggerx/daggy && cargo test

--- a/justfile
+++ b/justfile
@@ -112,11 +112,14 @@ reloadmod mod *args:
     echo "Docker is not running. Please start Docker and try again."; \
     exit 1; \
   fi
+  # @cd {{mod}} && dagger develop {{args}}
   @cd {{mod}} && dagger develop {{args}}
   @echo "Module reloaded successfully ✅"
 
 # Recipe to reload a Dagger module's tests (Dagger Develop) 🔄
 reloadtest mod *args:
+  #!/usr/bin/env sh
+  set -e
   @echo "Running Dagger development in a given module's tests..."
   @echo "Currently in {{mod}}/tests module 📦, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
@@ -158,8 +161,6 @@ examplesgo mod *args: (reloadmod mod)
 
 # Recipe to run GolangCI Lint 🧹
 golint mod *args:
-  #!/usr/bin/env sh
-  set -e
   @echo "Running Go (GolangCI)... 🧹 "
   @test -d {{mod}} || (echo "Module not found" && exit 1)
   @echo "Currently in {{mod}} module 📦, path=`pwd`/{{mod}}"
@@ -184,8 +185,6 @@ create mod with-ci='false' type='full':
 
 # Recipe to create a new light module using Daggy 🛠️
 createlight mod with-ci='false' type='light':
-  #!/usr/bin/env sh
-  set -e
   @echo "Creating a new {{type}} module of type {{type}}..."
   @cd .daggerx/daggy && cargo build --release
   @.daggerx/daggy/target/release/daggy --task=create --module={{mod}} --module-type={{type}}

--- a/justfile
+++ b/justfile
@@ -116,13 +116,13 @@ reloadtest mod *args:
   @echo "Module Tests reloaded successfully ✅"
 
 # Recipe to reload Dagger module and its underlying tests (Dagger Develop & Dagger Call/Functions) 🔄
-reloadall mod:
+reloadall mod *args:
   @echo "Reloading Dagger module and also the tests..."
   @echo "Currently in {{mod}} module 🔄, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger develop --sdk=go
-  @cd {{mod}}/tests && dagger develop --sdk=go
-  @cd {{mod}}/examples/go && dagger develop --sdk=go
+  @cd {{mod}} && dagger develop {{args}}
+  @cd {{mod}}/tests && dagger develop {{args}}
+  @cd {{mod}}/examples/go && dagger develop {{args}}
   @echo "Module reloaded successfully 🚀"
   @echo "Inspecting the module... 🕵️"
   @cd {{mod}} && dagger call && dagger functions
@@ -143,15 +143,15 @@ examplesgo mod *args: (reloadmod mod)
   @cd {{mod}}/examples/go && dagger call all-recipes {{args}}
 
 # Recipe to run GolangCI Lint 🧹
-golint mod:
+golint mod *args:
   @echo "Running Go (GolangCI)... 🧹 "
   @test -d {{mod}} || (echo "Module not found" && exit 1)
   @echo "Currently in {{mod}} module 📦, path=`pwd`/{{mod}}"
-  @cd ./{{mod}} && nix-shell -p golangci-lint --run "golangci-lint run --config ../.golangci.yml"
+  @cd ./{{mod}} && nix-shell -p golangci-lint --run "golangci-lint run --config ../.golangci.yml {{args}}"
   @echo "Checking now the tests 🧪 project ..."
-  @cd ./{{mod}}/tests && nix-shell -p golangci-lint --run "golangci-lint run --config ../../.golangci.yml"
+  @cd ./{{mod}}/tests && nix-shell -p golangci-lint --run "golangci-lint run --config ../../.golangci.yml {{args}}"
   @echo "Checking now the examples 📄 project ..."
-  @cd ./{{mod}}/examples/go && nix-shell -p golangci-lint --run "golangci-lint run --config ../../../.golangci.yml"
+  @cd ./{{mod}}/examples/go && nix-shell -p golangci-lint --run "golangci-lint run --config ../../../.golangci.yml {{args}}"
 
 # Recipe to run the whole CI locally 🚀
 cilocal mod: (reloadall mod) (golint mod) (test mod) (examplesgo mod) (ci-module-docs mod)
@@ -190,7 +190,7 @@ calltests mod *args: (reloadtest mod)
   @echo "Running Dagger call tests..."
   @echo "Currently in {{mod}} module 🧪, path=`pwd`"
   @test -d {{mod}}/tests || (echo "Module not found" && exit 1)
-  @cd {{mod}}/tests && dagger functions
+  @cd {{mod}}/tests && dagger functions {{args}}
   @cd {{mod}}/tests && dagger call {{args}}
 
 # Recipe to run dagger develop in all modules 🔄

--- a/justfile
+++ b/justfile
@@ -120,9 +120,9 @@ reloadall mod:
   @echo "Reloading Dagger module and also the tests..."
   @echo "Currently in {{mod}} module 🔄, path=`pwd`"
   @test -d {{mod}} || (echo "Module not found" && exit 1)
-  @cd {{mod}} && dagger develop
-  @cd {{mod}}/tests && dagger develop
-  @cd {{mod}}/examples/go && dagger develop
+  @cd {{mod}} && dagger develop --sdk=go
+  @cd {{mod}}/tests && dagger develop --sdk=go
+  @cd {{mod}}/examples/go && dagger develop --sdk=go
   @echo "Module reloaded successfully 🚀"
   @echo "Inspecting the module... 🕵️"
   @cd {{mod}} && dagger call && dagger functions

--- a/justfile
+++ b/justfile
@@ -256,7 +256,5 @@ listfns mod *args:
 
 # Recipe to run Daggy tests 🧪
 daggy-tests:
-  #!/usr/bin/env sh
-  set -e
   @echo "Running Daggy tests 🧪 ..."
   @cd .daggerx/daggy && cargo test


### PR DESCRIPTION
The changes in this commit update the `reloadall` command in the `justfile` to include the `--sdk=go` flag when running `dagger develop` commands for the module, its tests, and its examples.

This ensures that the Dagger SDK is correctly set when reloading the module, which is necessary for the module to function properly.