### PR TITLE
feat: Exclude additional directories from dagger build

### DIFF
--- a/gotoolbox/dagger.json
+++ b/gotoolbox/dagger.json
@@ -4,10 +4,11 @@
   "exclude": [
     "../.direnv",
     "../.devenv",
+    "../.vscode",
+    "../.idea",
+    "../.trunk",
     "../go.work",
-    "../go.work.sum",
-    "tests",
-    "examples/go"
+    "../go.work.sum"
   ],
   "source": ".",
   "engineVersion": "v0.13.3"


### PR DESCRIPTION
Exclude the following directories from the Dagger build:
- .vscode
- .idea
- .trunk
This ensures that development-specific files and directories are not included in the build, improving the overall build process.