### PR TITLE
feat: Update Git clone behavior with discardGitDir option

### DIFF
--- a/module-template-light/apis.go
+++ b/module-template-light/apis.go
@@ -194,9 +194,9 @@ func (m *ModuleTemplateLight) WithClonedGitRepoHTTPS(
 	// branch is the branch to checkout. Optional parameter.
 	// +optional
 	branch string,
-	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// discardGitDir is a boolean that indicates if the .git directory should be discarded. Optional parameter.
 	// +optional
-	keepGitDir bool,
+	discardGitDir bool,
 	// tag is the tag to checkout. Optional parameter.
 	// +optional
 	tag string,
@@ -205,7 +205,17 @@ func (m *ModuleTemplateLight) WithClonedGitRepoHTTPS(
 	commit string,
 ) *ModuleTemplateLight {
 	// Call the helper function to clone the repository.
-	clonedRepo := m.CloneGitRepoHTTPS(repoURL, token, vcs, authHeader, returnDir, branch, keepGitDir, tag, commit)
+	clonedRepo := m.CloneGitRepoHTTPS(
+		repoURL,
+		token,
+		vcs,
+		authHeader,
+		returnDir,
+		branch,
+		discardGitDir,
+		tag,
+		commit,
+	)
 
 	// Mount the cloned repository as a directory inside the container.
 	m.Ctr = m.Ctr.WithMountedDirectory(fixtures.MntPrefix, clonedRepo)

--- a/module-template-light/content.go
+++ b/module-template-light/content.go
@@ -78,9 +78,9 @@ func (m *ModuleTemplateLight) CloneGitRepoHTTPS(
 	// branch is the branch to checkout. Optional parameter.
 	// +optional
 	branch string,
-	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// discardGitDir is a boolean that indicates if the .git directory should be discarded. Optional parameter.
 	// +optional
-	keepGitDir bool,
+	discardGitDir bool,
 	// tag is the tag to checkout. Optional parameter.
 	// +optional
 	tag string,
@@ -95,8 +95,9 @@ func (m *ModuleTemplateLight) CloneGitRepoHTTPS(
 
 	gitCloneOpts := dagger.GitOpts{}
 
-	if keepGitDir {
-		gitCloneOpts.KeepGitDir = keepGitDir
+	// If discardGitDir is true, set KeepGitDir to false. This changed with 0.13.4
+	if discardGitDir {
+		gitCloneOpts.KeepGitDir = false
 	}
 
 	// Initialize the Git clone request.

--- a/module-template-light/examples/go/dagger.json
+++ b/module-template-light/examples/go/dagger.json
@@ -17,5 +17,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.13.3"
+  "engineVersion": "v0.13.5"
 }

--- a/module-template-light/tests/dagger.json
+++ b/module-template-light/tests/dagger.json
@@ -17,5 +17,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.13.3"
+  "engineVersion": "v0.13.5"
 }


### PR DESCRIPTION
This pull request updates the Git clone behavior with a new `discardGitDir` option. The key changes include:

- Renaming the `keepGitDir` parameter to `discardGitDir` in the `CloneGitRepoHTTPS` function
- Updating the `WithClonedGitRepoHTTPS` function to match the new parameter name
- Modifying the Git clone options to set `KeepGitDir` to `false` if `discardGitDir` is `true`
- Updating the Dagger engine version to `v0.13.5` in the test and example `dagger.json` files

These changes will provide more flexibility in managing the Git directory during the cloning process.