### PR TITLE
fix: Change the "keepGitDir" parameter to "discardGitDir" in the Git clone function

### DIFF
--- a/.github/workflows/ci-mod-module-template-light.yaml
+++ b/.github/workflows/ci-mod-module-template-light.yaml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.13.0, 0.13.1, 0.13.2, 0.13.3]
+                dagversion: [0.13.4, 0.13.5]
         name: Lint module-template-light on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
         steps:
@@ -159,7 +159,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.13.0, 0.13.1, 0.13.2, 0.13.3]
+                dagversion: [0.13.4, 0.13.5]
         needs: [dagger-linter, golangci-lint]
         name: Run Tests 🧪 in module-template-light on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
         strategy:
             matrix:
                 go: ['1.22']
-                dagversion: [0.13.3]
+                dagversion: [0.13.5]
         needs: [dagger-linter, golangci-lint]
         name: Run recipes 🥗 in module-template-light/examples/go on ${{ matrix.os }} with Dagger ${{ matrix.dagversion }}
         runs-on: ubuntu-latest

--- a/module-template-light/apis.go
+++ b/module-template-light/apis.go
@@ -249,9 +249,9 @@ func (m *ModuleTemplateLight) WithClonedGitRepoSSH(
 	// branch is the branch to checkout. Optional parameter.
 	// +optional
 	branch string,
-	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// discardGitDir is a boolean that indicates if the .git directory should be discarded. Optional parameter.
 	// +optional
-	keepGitDir bool,
+	discardGitDir bool,
 	// tag is the tag to checkout. Optional parameter.
 	// +optional
 	tag string,
@@ -260,7 +260,16 @@ func (m *ModuleTemplateLight) WithClonedGitRepoSSH(
 	commit string,
 ) *ModuleTemplateLight {
 	// Call the helper function to clone the repository.
-	clonedRepo := m.CloneGitRepoSSH(repoURL, sshAuthSocket, sshKnownHosts, returnDir, branch, keepGitDir, tag, commit)
+	clonedRepo := m.CloneGitRepoSSH(
+		repoURL,
+		sshAuthSocket,
+		sshKnownHosts,
+		returnDir,
+		branch,
+		discardGitDir,
+		tag,
+		commit,
+	)
 
 	// Mount the cloned repository as a directory inside the container.
 	m.Ctr = m.

--- a/module-template-light/content.go
+++ b/module-template-light/content.go
@@ -168,9 +168,9 @@ func (m *ModuleTemplateLight) CloneGitRepoSSH(
 	// branch is the branch to checkout. Optional parameter.
 	// +optional
 	branch string,
-	// keepGitDir is a boolean that indicates if the .git directory should be kept. Optional parameter.
+	// discardGitDir is a boolean that indicates if the .git directory should be discarded. Optional parameter.
 	// +optional
-	keepGitDir bool,
+	discardGitDir bool,
 	// tag is the tag to checkout. Optional parameter.
 	// +optional
 	tag string,
@@ -182,8 +182,9 @@ func (m *ModuleTemplateLight) CloneGitRepoSSH(
 		SSHAuthSocket: sshAuthSocket,
 	}
 
-	if keepGitDir {
-		gitCloneOpts.KeepGitDir = keepGitDir
+	// If discardGitDir is true, set KeepGitDir to false. This changed with 0.13.4
+	if discardGitDir {
+		gitCloneOpts.KeepGitDir = false
 	}
 
 	if sshKnownHosts != "" {


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ The commit changes the "keepGitDir" parameter to "discardGitDir" in the Git clone function.
* 🎉 This ensures the repository is cloned correctly and the Git directory is properly discarded, as per the latest updates to the module-template-light library.

## 🤔 Why
Explain why the changes are necessary:
* 💡 The "keepGitDir" parameter is now deprecated in version 0.13.4 of the module-template-light library, and the new "discardGitDir" parameter should be used instead.
* 🎯 This change will keep the codebase up-to-date with the latest library version and ensure that the Git repository is cloned correctly.

## 📚 References
Link any supporting context or documentation:
* 🔗 This change is introduced in version 0.13.4 of the module-template-light library.