### PR TITLE
fix: Remove redundant terragrunt init command

### DIFF
--- a/terragrunt/tests/terragrunt.go
+++ b/terragrunt/tests/terragrunt.go
@@ -297,26 +297,6 @@ func (m *Tests) TestTerragruntExecLifecycleCommands(ctx context.Context) error {
 			TfLogPath: "/mnt/tflogs", // it's a directory that the terragrunt user owns.
 		})
 
-	// run init command
-	cmdInitOut, cmdInitErr := tgModule.ExecCmd(ctx, "init", dagger.TerragruntExecCmdOpts{
-		Source: m.
-			getTestDir("").
-			Directory("terragrunt"),
-		Secrets: []*dagger.Secret{
-			awsSecret,
-			gcpSecret,
-			azureSecret,
-		},
-	})
-
-	if cmdInitErr != nil {
-		return WrapErrorf(cmdInitErr, "failed to execute command init")
-	}
-
-	if cmdInitOut == "" {
-		return Errorf("command init output is empty")
-	}
-
 	// run plan command with arguments
 	cmdPlanOut, cmdPlanErr := tgModule.ExecCmd(ctx, "plan", dagger.TerragruntExecCmdOpts{
 		Source: m.


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ The changes remove the redundant `terragrunt init` command from the test case.
* 🎉 This simplifies the test by removing unnecessary code, as the `terragrunt plan` command already initializes the Terragrunt environment.

## 🤔 Why
Explain why the changes are necessary:
* 💡 The `terragrunt init` command was redundant and not necessary for the test case, as the `terragrunt plan` command already initializes the Terragrunt environment.
* 🎯 Removing the `init` command simplifies the test and removes unnecessary code, making the test case more concise and easier to maintain.

## 📚 References
Link any supporting context or documentation:
* 🔗 The changes are based on the commit message provided.