### PR TITLE
add-socket-ssh-support

### DIFF
--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -141,10 +141,10 @@ func (m *Terragrunt) WithIACToolsInstalled(tgVersion, tfVersion, openTofuVersion
 		WithOpenTofuInstalled(openTofuVersion)
 }
 
-// WithModulesWithSourceInSSH configures the container to use SSH authentication for Terragrunt modules with SSH sources.
+// WithSSHAuthForTerraformModules configures SSH authentication for Terraform modules with Git SSH sources.
 //
-// This function mounts an SSH authentication socket into the container, allowing Terragrunt to authenticate
-// when fetching modules from SSH sources (e.g., private Git repositories).
+// This function mounts an SSH authentication socket into the container, enabling Terraform to authenticate
+// when fetching modules from Git repositories using SSH URLs (e.g., git@github.com:org/repo.git).
 //
 // Parameters:
 //   - sshAuthSocket: The SSH authentication socket to mount in the container.
@@ -152,8 +152,8 @@ func (m *Terragrunt) WithIACToolsInstalled(tgVersion, tfVersion, openTofuVersion
 //   - owner: Optional. The owner of the mounted socket in the container.
 //
 // Returns:
-//   - *Terragrunt: The updated Terragrunt instance with SSH authentication configured.
-func (m *Terragrunt) WithModulesWithSourceInSSH(
+//   - *Terragrunt: The updated Terragrunt instance with SSH authentication configured for Terraform modules.
+func (m *Terragrunt) WithSSHAuthForTerraformModules(
 	// sshAuthSocket is the SSH socket to use for authentication.
 	sshAuthSocket *dagger.Socket,
 	// socketPath is the path where the SSH socket will be mounted in the container.

--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -140,3 +140,36 @@ func (m *Terragrunt) WithIACToolsInstalled(tgVersion, tfVersion, openTofuVersion
 		WithTerraformInstalled(tfVersion).
 		WithOpenTofuInstalled(openTofuVersion)
 }
+
+// WithModulesWithSourceInSSH configures the container to use SSH authentication for Terragrunt modules with SSH sources.
+//
+// This function mounts an SSH authentication socket into the container, allowing Terragrunt to authenticate
+// when fetching modules from SSH sources (e.g., private Git repositories).
+//
+// Parameters:
+//   - sshAuthSocket: The SSH authentication socket to mount in the container.
+//   - socketPath: The path where the SSH socket will be mounted in the container.
+//   - owner: Optional. The owner of the mounted socket in the container.
+//
+// Returns:
+//   - *Terragrunt: The updated Terragrunt instance with SSH authentication configured.
+func (m *Terragrunt) WithModulesWithSourceInSSH(
+	// sshAuthSocket is the SSH socket to use for authentication.
+	sshAuthSocket *dagger.Socket,
+	// socketPath is the path where the SSH socket will be mounted in the container.
+	socketPath string,
+	// owner is the owner of the mounted socket in the container. Optional parameter.
+	// +optional
+	owner string,
+) *Terragrunt {
+	socketOpts := dagger.ContainerWithUnixSocketOpts{}
+
+	if owner != "" {
+		socketOpts.Owner = owner
+	}
+
+	m.Ctr = m.Ctr.
+		WithUnixSocket(socketPath, sshAuthSocket, socketOpts)
+
+	return m
+}


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ Added support for SSH authentication when fetching Terraform modules from private Git repositories using SSH URLs.
* 🎉 Users can now use SSH authentication to access private Terraform modules, without needing to provide credentials directly in their code.

## 🤔 Why
* 💡 These changes were made to enable Terragrunt to authenticate with private Git repositories when fetching Terraform modules.
* 🎯 This will allow users to keep their SSH credentials secure and manage access to private modules more easily.

## 📚 References
* 🔗 This pull request addresses the need for SSH support as described in issue #123.