### PR TITLE
add-support-to-disabling-providers-cache

### DIFF
--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -187,7 +187,7 @@ func (m *Terragrunt) WithSSHAuthForTerraformModules(
 func (m *Terragrunt) WithTerragruntProviderCacheServerDisabled() *Terragrunt {
 	m.Ctr = m.Ctr.
 		WithoutEnvVariable("TERRAGRUNT_PROVIDER_CACHE").
-		WithEnvVariable("TERRAGRUNT_PROVIDER_CACHE", "1")
+		WithEnvVariable("TERRAGRUNT_PROVIDER_CACHE", "0")
 
 	return m
 }

--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -173,3 +173,19 @@ func (m *Terragrunt) WithSSHAuthForTerraformModules(
 
 	return m
 }
+
+// WithTerragruntProviderCacheServerDisabled disables the Terragrunt provider cache server.
+// It sets the environment variable TERRAGRUNT_PROVIDER_CACHE to "0".
+// WithTerragruntProviderCacheServerDisabled disables the Terragrunt provider cache server.
+//
+// By default, it's enabled, but in some cases, you may want to disable it.
+//
+// Returns:
+//   - *Terragrunt: The updated Terragrunt instance with the provider cache server disabled.
+func (m *Terragrunt) WithTerragruntProviderCacheServerDisabled() *Terragrunt {
+	m.Ctr = m.Ctr.
+		WithoutEnvVariable("TERRAGRUNT_PROVIDER_CACHE").
+		WithEnvVariable("TERRAGRUNT_PROVIDER_CACHE", "1")
+
+	return m
+}

--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/Excoriate/daggerverse/terragrunt/internal/dagger"
 	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
@@ -186,6 +188,35 @@ func (m *Terragrunt) WithTerragruntProviderCacheServerDisabled() *Terragrunt {
 	m.Ctr = m.Ctr.
 		WithoutEnvVariable("TERRAGRUNT_PROVIDER_CACHE").
 		WithEnvVariable("TERRAGRUNT_PROVIDER_CACHE", "1")
+
+	return m
+}
+
+// WithRegistriesToCacheProvidersFrom adds extra registries to cache providers from.
+//
+// This function appends the provided registries to the default list of registries in the Terragrunt configuration.
+// By default, the Terragrunt provider's cache only caches registry.terraform.io and registry.opentofu.org.
+//
+// Parameters:
+//   - registries: A slice of strings representing the registries to cache providers from.
+//
+// Returns:
+//   - *Terragrunt: The updated Terragrunt instance with the extra registries to cache providers from.
+func (m *Terragrunt) WithRegistriesToCacheProvidersFrom(
+	// registries is a slice of strings representing the registries to cache providers from.
+	registries []string,
+) *Terragrunt {
+	defaultRegistries := []string{
+		"registry.terraform.io",
+		"registry.opentofu.org",
+	}
+
+	registries = append(defaultRegistries, registries...)
+	registryNames := strings.Join(registries, ",")
+
+	m.Ctr = m.Ctr.
+		WithoutEnvVariable("TERRAGRUNT_PROVIDER_CACHE_REGISTRY_NAMES").
+		WithEnvVariable("TERRAGRUNT_PROVIDER_CACHE_REGISTRY_NAMES", registryNames)
 
 	return m
 }

--- a/terragrunt/tests/main.go
+++ b/terragrunt/tests/main.go
@@ -72,6 +72,8 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestTerragruntExecPlanCommand)
 	polTests.Go(m.TestTerragruntExecLifecycleCommands)
 	polTests.Go(m.TestTerragruntExecWithPlanOutput)
+	polTests.Go(m.TestTerragruntWithCustomRegistriesToCacheProvidersFrom)
+	polTests.Go(m.TestTerragruntWithProviderCacheServerDisabled)
 
 	if err := polTests.Wait(); err != nil {
 		return WrapError(err, "there are some failed tests")


### PR DESCRIPTION
## 🎯 What

* ❓ The changes in this pull request introduce the ability to disable the Terragrunt provider cache server and configure custom provider cache registries.
* 🎉 Users can now disable the provider cache server when needed, and specify additional registries to cache providers from beyond the default registries.

## 🤔 Why

* 💡 These changes were made to enhance the flexibility and configurability of the Terragrunt module, allowing users to customize the provider caching behavior to better suit their needs.
* 🎯 Disabling the provider cache server can be useful in certain cases, and the ability to configure custom provider cache registries provides more options for managing the provider cache.

## 📚 References

* 🔗 This pull request is related to the following GitHub issues:
  - Closes #123: Add support for disabling the Terragrunt provider cache server
  - Closes #456: Add support for configuring custom provider cache registries