### PR TITLE
feat-add-native-cmd-support

### DIFF
--- a/terragrunt/config.go
+++ b/terragrunt/config.go
@@ -1,0 +1,33 @@
+package main
+
+// Entrypoint represents the entrypoint to use when executing the command.
+type Entrypoint string
+
+const (
+	// TerragruntEntrypoint specifies the entrypoint for Terragrunt.
+	TerragruntEntrypoint Entrypoint = "terragrunt"
+	// TerraformEntrypoint specifies the entrypoint for Terraform.
+	TerraformEntrypoint Entrypoint = "terraform"
+	// OpentofuEntrypoint specifies the entrypoint for Opentofu.
+	OpentofuEntrypoint Entrypoint = "opentofu"
+)
+
+// IsValidIACTool validates the IaC tool.
+func IsValidIACTool(tool string) error {
+	validTools := []Entrypoint{TerragruntEntrypoint, TerraformEntrypoint, OpentofuEntrypoint}
+	isValidTool := false
+
+	for _, valid := range validTools {
+		if tool == string(valid) {
+			isValidTool = true
+
+			break
+		}
+	}
+
+	if !isValidTool {
+		return WrapErrorf(nil, "invalid entrypoint: %s. Must be one of: %v", tool, validTools)
+	}
+
+	return nil
+}

--- a/terragrunt/config.go
+++ b/terragrunt/config.go
@@ -1,20 +1,20 @@
 package main
 
-// Entrypoint represents the entrypoint to use when executing the command.
-type Entrypoint string
+// Tool represents the entrypoint to use when executing the command.
+type Tool string
 
 const (
-	// TerragruntEntrypoint specifies the entrypoint for Terragrunt.
-	TerragruntEntrypoint Entrypoint = "terragrunt"
-	// TerraformEntrypoint specifies the entrypoint for Terraform.
-	TerraformEntrypoint Entrypoint = "terraform"
-	// OpentofuEntrypoint specifies the entrypoint for Opentofu.
-	OpentofuEntrypoint Entrypoint = "opentofu"
+	// TerragruntTool specifies the tool for Terragrunt.
+	TerragruntTool Tool = "terragrunt"
+	// TerraformTool specifies the tool for Terraform.
+	TerraformTool Tool = "terraform"
+	// OpentofuTool specifies the tool for Opentofu.
+	OpentofuTool Tool = "opentofu"
 )
 
 // IsValidIACTool validates the IaC tool.
 func IsValidIACTool(tool string) error {
-	validTools := []Entrypoint{TerragruntEntrypoint, TerraformEntrypoint, OpentofuEntrypoint}
+	validTools := []Tool{TerragruntTool, TerraformTool, OpentofuTool}
 	isValidTool := false
 
 	for _, valid := range validTools {
@@ -26,7 +26,7 @@ func IsValidIACTool(tool string) error {
 	}
 
 	if !isValidTool {
-		return WrapErrorf(nil, "invalid entrypoint: %s. Must be one of: %v", tool, validTools)
+		return WrapErrorf(nil, "invalid tool: %s. Must be one of: %v", tool, validTools)
 	}
 
 	return nil

--- a/terragrunt/config/presets/base-alpine.yaml
+++ b/terragrunt/config/presets/base-alpine.yaml
@@ -1,86 +1,91 @@
 ---
 contents:
-    repositories:
-        - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
-        - https://dl-cdn.alpinelinux.org/alpine/v3.18/community
-    packages:
-        - alpine-baselayout
-        - alpine-keys
-        - apk-tools
-        - ca-certificates-bundle
-        - musl
-        - curl
-        - bash
-        - unzip
-        - wget
-        - git
-        - tzdata
-        - openssl
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/community
+  packages:
+    - alpine-baselayout
+    - alpine-keys
+    - apk-tools
+    - ca-certificates-bundle
+    - musl
+    - curl
+    - bash
+    - unzip
+    - wget
+    - git
+    - tzdata
+    - openssl
 
 accounts:
-    groups:
-        - groupname: terragrunt
-          gid: 65532
-    users:
-        - username: terragrunt
-          uid: 65532
-          gid: 65532
-    run-as: terragrunt
+  groups:
+    - groupname: terragrunt
+      gid: 65532
+  users:
+    - username: terragrunt
+      uid: 65532
+      gid: 65532
+  run-as: terragrunt
 
 entrypoint:
-    command: /bin/bash -l
+  command: /bin/bash -l
 
 archs:
-    - x86_64
-    - aarch64
+  - x86_64
+  - aarch64
 
 environment:
-    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/terragrunt/bin:/home/terragrunt/.local/bin
-    TERRAGRUNT_PROVIDER_CACHE_DIR: /home/terragrunt/.terragrunt-providers-cache
-    TERRAGRUNT_PROVIDER_CACHE: '1'
-    TF_PLUGIN_CACHE_DIR: /home/.terraform.d/plugin-cache
-    TZ: UTC
-    LANG: en_US.UTF-8
-    LC_ALL: en_US.UTF-8
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/terragrunt/bin:/home/terragrunt/.local/bin
+  TERRAGRUNT_PROVIDER_CACHE_DIR: /home/terragrunt/.terragrunt-providers-cache
+  TERRAGRUNT_PROVIDER_CACHE: "1"
+  TF_PLUGIN_CACHE_DIR: /home/.terraform.d/plugin-cache
+  TZ: UTC
+  LANG: en_US.UTF-8
+  LC_ALL: en_US.UTF-8
 
 paths:
-    - path: /home/terragrunt
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
-    - path: /home/terragrunt/bin
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
-    - path: /home/terragrunt/.terragrunt-providers-cache
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
-    - path: /home/.terraform.d/plugin-cache
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
-    - path: /home/.terraform.d/plugins
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
+  - path: /home/terragrunt
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/terragrunt/bin
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/terragrunt/.terragrunt-providers-cache
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/.terraform.d/plugin-cache
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/.terraform.d/plugins
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/.terraform.d/providers
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
   # Default /mnt directory
-    - path: /mnt
-      type: directory
-      uid: 65532
-      gid: 65532
-      permissions: 0o755
+  - path: /mnt
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
 
 annotations:
-    title: Base Alpine for Terragrunt
-    description: A minimal Alpine base image built with APKO for Terragrunt, optimized for security and performance.
-    version: 1.1.0
-    vendor: github.com/Excoriate - Alex Torres
-    licenses: Apache-2.0
-    url: https://github.com/Excoriate/daggerverse
-    source: https://github.com/Excoriate/daggerverse
+  title: Base Alpine for Terragrunt
+  description: A minimal Alpine base image built with APKO for Terragrunt, optimized for security and performance.
+  version: 1.1.0
+  vendor: github.com/Excoriate - Alex Torres
+  licenses: Apache-2.0
+  url: https://github.com/Excoriate/daggerverse
+  source: https://github.com/Excoriate/daggerverse

--- a/terragrunt/iac_cmd.go
+++ b/terragrunt/iac_cmd.go
@@ -67,58 +67,6 @@ type Cmd interface {
 		tool string,
 	) (*dagger.Container, error)
 
-	// TfExec executes a given Terraform command within a Dagger container.
-	//
-	// Parameters:
-	// - ctx: The context for controlling the execution.
-	// - command: The Terraform command to execute.
-	// - args: The arguments for the command.
-	// - autoApprove: Flag to auto-approve prompts.
-	// - source: The source directory for the command.
-	// - module: The module to execute. +optional
-	// - envVars: The environment variables to pass to the container. +optional
-	// - secrets: The secrets to pass to the container. +optional
-	//
-	// Returns:
-	// - *dagger.Container: Pointer to the resulting container.
-	// - error: If execution fails.
-	TfExec(
-		ctx context.Context,
-		command string,
-		args []string,
-		autoApprove bool,
-		source *dagger.Directory,
-		module string,
-		envVars []string,
-		secrets []*dagger.Secret,
-	) (*dagger.Container, error)
-
-	// TfExecCmd executes a given Terragrunt command within a Dagger container.
-	//
-	// Parameters:
-	// - ctx: The context for controlling the execution.
-	// - command: The Terragrunt command to execute.
-	// - args: The arguments for the command.
-	// - autoApprove: Flag to auto-approve prompts.
-	// - source: The source directory for the command.
-	// - module: The module to execute. +optional
-	// - envVars: The environment variables to pass to the container. +optional
-	// - secrets: The secrets to pass to the container. +optional
-	//
-	// Returns:
-	// - *dagger.Container: Pointer to the resulting container.
-	// - error: If execution fails.
-	TfExecCmd(
-		ctx context.Context,
-		command string,
-		args []string,
-		autoApprove bool,
-		source *dagger.Directory,
-		module string,
-		envVars []string,
-		secrets []*dagger.Secret,
-	) (*dagger.Container, error)
-
 	// validate checks if the provided command is recognized by the IaC tool.
 	//
 	// Returns an error for invalid or empty commands.

--- a/terragrunt/iac_cmd.go
+++ b/terragrunt/iac_cmd.go
@@ -6,13 +6,55 @@ import (
 	"github.com/Excoriate/daggerverse/terragrunt/internal/dagger"
 )
 
-// Cmd is an interface that represents a command to be executed by Terragrunt.
+// Cmd defines the interface for executing commands in Infrastructure as Code (IaC) tools
+// such as Terraform, Terragrunt, and OpenTofu within a Dagger container.
 // Cmd defines the interface for executing commands in Infrastructure as Code (IaC) tools
 // such as Terraform, Terragrunt, and OpenTofu within a Dagger container.
 type Cmd interface {
 	// Exec executes a given IaC command within a Dagger container.
-	// Returns a pointer to the resulting dagger.Container or an error.
+	//
+	// Parameters:
+	// - ctx: The context for controlling the execution.
+	// - command: The IaC command to execute.
+	// - args: The arguments for the command.
+	// - autoApprove: Flag to auto-approve prompts.
+	// - source: The source directory for the command.
+	// - module: The module to execute or the terragrunt configuration where the terragrunt.hcl file is located. +optional
+	// - envVars: The environment variables to pass to the container. +optional
+	// - secrets: The secrets to pass to the container. +optional
+	// - entrypoint: The entrypoint to use for executing the command.
+	//
+	// Returns:
+	// - *dagger.Container: Pointer to the resulting container.
+	// - error: If execution fails.
 	Exec(
+		ctx context.Context,
+		command string,
+		args []string,
+		autoApprove bool,
+		source *dagger.Directory,
+		module string,
+		envVars []string,
+		secrets []*dagger.Secret,
+		entrypoint Entrypoint,
+	) (*dagger.Container, error)
+
+	// ExecCmd executes a given command within a Dagger container.
+	//
+	// Parameters:
+	// - ctx: The context for controlling the execution.
+	// - command: The command to execute.
+	// - args: The arguments for the command.
+	// - autoApprove: Flag to auto-approve prompts.
+	// - source: The source directory for the command.
+	// - module: The module to execute. +optional
+	// - envVars: The environment variables to pass to the container. +optional
+	// - secrets: The secrets to pass to the container. +optional
+	//
+	// Returns:
+	// - *dagger.Container: Pointer to the resulting container.
+	// - error: If execution fails.
+	ExecCmd(
 		ctx context.Context,
 		command string,
 		args []string,
@@ -23,7 +65,64 @@ type Cmd interface {
 		secrets []*dagger.Secret,
 	) (*dagger.Container, error)
 
+	// TfExecCmd executes a given Terraform command within a Dagger container.
+	//
+	// Parameters:
+	// - ctx: The context for controlling the execution.
+	// - command: The Terraform command to execute.
+	// - args: The arguments for the command.
+	// - autoApprove: Flag to auto-approve prompts.
+	// - source: The source directory for the command.
+	// - module: The module to execute. +optional
+	// - envVars: The environment variables to pass to the container. +optional
+	// - secrets: The secrets to pass to the container. +optional
+	// - entrypoint: The entrypoint to use for executing the command.
+	//
+	// Returns:
+	// - *dagger.Container: Pointer to the resulting container.
+	// - error: If execution fails.
+	TfExecCmd(
+		ctx context.Context,
+		command string,
+		args []string,
+		autoApprove bool,
+		source *dagger.Directory,
+		module string,
+		envVars []string,
+		secrets []*dagger.Secret,
+		entrypoint Entrypoint,
+	) (*dagger.Container, error)
+
+	// TgExecCmd executes a given Terragrunt command within a Dagger container.
+	//
+	// Parameters:
+	// - ctx: The context for controlling the execution.
+	// - command: The Terragrunt command to execute.
+	// - args: The arguments for the command.
+	// - autoApprove: Flag to auto-approve prompts.
+	// - source: The source directory for the command.
+	// - module: The module to execute. +optional
+	// - envVars: The environment variables to pass to the container. +optional
+	// - secrets: The secrets to pass to the container. +optional
+	// - entrypoint: The entrypoint to use for executing the command.
+	//
+	// Returns:
+	// - *dagger.Container: Pointer to the resulting container.
+	// - error: If execution fails.
+	TgExecCmd(
+		ctx context.Context,
+		command string,
+		args []string,
+		autoApprove bool,
+		source *dagger.Directory,
+		module string,
+		envVars []string,
+		secrets []*dagger.Secret,
+		entrypoint Entrypoint,
+	) (*dagger.Container, error)
+
 	// validate checks if the provided command is recognized by the IaC tool.
+	//
 	// Returns an error for invalid or empty commands.
 	validate(command string) error
 

--- a/terragrunt/iac_cmd.go
+++ b/terragrunt/iac_cmd.go
@@ -36,7 +36,7 @@ type Cmd interface {
 		module string,
 		envVars []string,
 		secrets []*dagger.Secret,
-		entrypoint Entrypoint,
+		tool string,
 	) (*dagger.Container, error)
 
 	// ExecCmd executes a given command within a Dagger container.

--- a/terragrunt/iac_cmd.go
+++ b/terragrunt/iac_cmd.go
@@ -22,7 +22,7 @@ type Cmd interface {
 	// - module: The module to execute or the terragrunt configuration where the terragrunt.hcl file is located. +optional
 	// - envVars: The environment variables to pass to the container. +optional
 	// - secrets: The secrets to pass to the container. +optional
-	// - entrypoint: The entrypoint to use for executing the command.
+	// - tool: The tool to use for executing the command.
 	//
 	// Returns:
 	// - *dagger.Container: Pointer to the resulting container.
@@ -50,6 +50,7 @@ type Cmd interface {
 	// - module: The module to execute. +optional
 	// - envVars: The environment variables to pass to the container. +optional
 	// - secrets: The secrets to pass to the container. +optional
+	// - tool: The tool to use for executing the command.
 	//
 	// Returns:
 	// - *dagger.Container: Pointer to the resulting container.
@@ -63,9 +64,10 @@ type Cmd interface {
 		module string,
 		envVars []string,
 		secrets []*dagger.Secret,
+		tool string,
 	) (*dagger.Container, error)
 
-	// TfExecCmd executes a given Terraform command within a Dagger container.
+	// TfExec executes a given Terraform command within a Dagger container.
 	//
 	// Parameters:
 	// - ctx: The context for controlling the execution.
@@ -76,7 +78,32 @@ type Cmd interface {
 	// - module: The module to execute. +optional
 	// - envVars: The environment variables to pass to the container. +optional
 	// - secrets: The secrets to pass to the container. +optional
-	// - entrypoint: The entrypoint to use for executing the command.
+	//
+	// Returns:
+	// - *dagger.Container: Pointer to the resulting container.
+	// - error: If execution fails.
+	TfExec(
+		ctx context.Context,
+		command string,
+		args []string,
+		autoApprove bool,
+		source *dagger.Directory,
+		module string,
+		envVars []string,
+		secrets []*dagger.Secret,
+	) (*dagger.Container, error)
+
+	// TfExecCmd executes a given Terragrunt command within a Dagger container.
+	//
+	// Parameters:
+	// - ctx: The context for controlling the execution.
+	// - command: The Terragrunt command to execute.
+	// - args: The arguments for the command.
+	// - autoApprove: Flag to auto-approve prompts.
+	// - source: The source directory for the command.
+	// - module: The module to execute. +optional
+	// - envVars: The environment variables to pass to the container. +optional
+	// - secrets: The secrets to pass to the container. +optional
 	//
 	// Returns:
 	// - *dagger.Container: Pointer to the resulting container.
@@ -90,35 +117,6 @@ type Cmd interface {
 		module string,
 		envVars []string,
 		secrets []*dagger.Secret,
-		entrypoint Entrypoint,
-	) (*dagger.Container, error)
-
-	// TgExecCmd executes a given Terragrunt command within a Dagger container.
-	//
-	// Parameters:
-	// - ctx: The context for controlling the execution.
-	// - command: The Terragrunt command to execute.
-	// - args: The arguments for the command.
-	// - autoApprove: Flag to auto-approve prompts.
-	// - source: The source directory for the command.
-	// - module: The module to execute. +optional
-	// - envVars: The environment variables to pass to the container. +optional
-	// - secrets: The secrets to pass to the container. +optional
-	// - entrypoint: The entrypoint to use for executing the command.
-	//
-	// Returns:
-	// - *dagger.Container: Pointer to the resulting container.
-	// - error: If execution fails.
-	TgExecCmd(
-		ctx context.Context,
-		command string,
-		args []string,
-		autoApprove bool,
-		source *dagger.Directory,
-		module string,
-		envVars []string,
-		secrets []*dagger.Secret,
-		entrypoint Entrypoint,
 	) (*dagger.Container, error)
 
 	// validate checks if the provided command is recognized by the IaC tool.

--- a/terragrunt/terragrunt_cfg.go
+++ b/terragrunt/terragrunt_cfg.go
@@ -8,14 +8,15 @@ import (
 )
 
 const (
-	terragruntCacheDir  = "/home/terragrunt/.terragrunt-providers-cache"
-	terraformCacheDir   = "/home/.terraform.d/plugin-cache"
-	terraformPluginsDir = "/home/.terraform.d/plugins"
-	terragruntHomeDir   = "/home/terragrunt"
-	terraformDir        = "/home/.terraform.d"
-	homeDir             = "/home"
-	varLogDir           = "/var/log"
-	mntPrefixDefault    = fixtures.MntPrefix
+	terragruntCacheDir    = "/home/terragrunt/.terragrunt-providers-cache"
+	terraformCacheDir     = "/home/.terraform.d/plugin-cache"
+	terraformProvidersDir = "/home/.terraform.d/providers"
+	terraformPluginsDir   = "/home/.terraform.d/plugins"
+	terragruntHomeDir     = "/home/terragrunt"
+	terraformDir          = "/home/.terraform.d"
+	homeDir               = "/home"
+	varLogDir             = "/var/log"
+	mntPrefixDefault      = fixtures.MntPrefix
 )
 
 // WithTerragruntPermissionsOnDirsDefault sets the default permissions for the Terragrunt directories.
@@ -40,6 +41,7 @@ func (m *Terragrunt) WithTerragruntPermissionsOnDirsDefault() *Terragrunt {
 		homeDir,
 		varLogDir,
 		mntPrefixDefault,
+		terraformProvidersDir,
 	}
 
 	return m.

--- a/terragrunt/terragrunt_cmds.go
+++ b/terragrunt/terragrunt_cmds.go
@@ -199,6 +199,25 @@ func (m *Terragrunt) ExecCmd(
 	return output, nil
 }
 
+// TfExec executes a Terraform command within the Terragrunt context.
+//
+// This function takes the specified command and its arguments, executes it in the
+// context of the provided source directory, and returns a pointer to the resulting
+// container or an error if the execution fails.
+//
+// Parameters:
+// - ctx: The context to use when executing the command.
+// - command: The terraform command to execute. It's the actual command that comes after 'terraform'.
+// - args: The arguments to pass to the command.
+// - autoApprove: The flag to auto approve the command.
+// - source: The source directory that includes the source code.
+// - module: The module to execute or the terraform configuration where the main.tf file is located.
+// - envVars: The environment variables to pass to the container.
+// - secrets: The secrets to pass to the container.
+//
+// Returns:
+// - *dagger.Container: A pointer to the resulting container.
+// - error: An error if the command execution fails.
 func (m *Terragrunt) TfExec(
 	// ctx is the context to use when executing the command.
 	// +optional
@@ -228,6 +247,25 @@ func (m *Terragrunt) TfExec(
 	return m.Exec(ctx, command, args, autoApprove, source, module, envVars, secrets, string(TerraformTool))
 }
 
+// TfExecCmd executes a Terraform command within the Terragrunt context.
+//
+// This function takes the specified command and its arguments, executes it in the
+// context of the provided source directory, and returns the standard output as a string.
+// If any error occurs during execution, it returns an error with a descriptive message.
+//
+// Parameters:
+// - ctx: The context to use when executing the command.
+// - command: The terraform command to execute. It's the actual command that comes after 'terraform'.
+// - args: The arguments to pass to the command.
+// - autoApprove: The flag to auto approve the command.
+// - source: The source directory that includes the source code.
+// - module: The module to execute or the terraform configuration where the main.tf file is located.
+// - envVars: The environment variables to pass to the container.
+// - secrets: The secrets to pass to the container.
+//
+// Returns:
+// - string: The standard output from the executed command.
+// - error: An error if the command execution fails.
 func (m *Terragrunt) TfExecCmd(
 	// ctx is the context to use when executing the command.
 	// +optional

--- a/terragrunt/tests/main.go
+++ b/terragrunt/tests/main.go
@@ -74,6 +74,7 @@ func (m *Tests) TestAll(ctx context.Context) error {
 	polTests.Go(m.TestTerragruntExecWithPlanOutput)
 	polTests.Go(m.TestTerragruntWithCustomRegistriesToCacheProvidersFrom)
 	polTests.Go(m.TestTerragruntWithProviderCacheServerDisabled)
+	polTests.Go(m.TestTfExecInitSimpleCommand)
 
 	if err := polTests.Wait(); err != nil {
 		return WrapError(err, "there are some failed tests")

--- a/terragrunt/tests/terraform.go
+++ b/terragrunt/tests/terraform.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+
+	"github.com/Excoriate/daggerverse/terragrunt/tests/internal/dagger"
+)
+
+// TestTfExecInitSimpleCommand tests the execution of the 'terraform init' command with a simple
+// configuration.
+// It sets up the necessary environment variables, initializes the Terragrunt module, and executes the 'init'
+// command.
+// The function then validates the output of the command and checks if the environment variables are correctly set
+// in the container.
+// If any step fails, an error is returned.
+func (m *Tests) TestTfExecInitSimpleCommand(ctx context.Context) error {
+	testEnvVars := []string{
+		"AWS_ACCESS_KEY_ID=AKIAEXAMPLE",
+		"AWS_SECRET_ACCESS_KEY=secretKey12345",
+		"AWS_SESSION_TOKEN=sessionToken67890",
+		"AWS_REGION=us-west-2",
+	}
+
+	// Initialize the Terragrunt module
+	tgModule := dag.
+		Terragrunt(dagger.TerragruntOpts{
+			EnvVarsFromHost: testEnvVars,
+			TfVersion:       "1.9.1",
+		}).
+		WithTerragruntPermissionsOnDirsDefault().
+		WithTerragruntLogOptions(
+			dagger.TerragruntWithTerragruntLogOptionsOpts{
+				TgLogLevel:        "debug",
+				TgForwardTfStdout: true,
+			},
+		)
+
+	// Execute the init command, but don't run it in a container
+	tfInitCtr := tgModule.
+		TfExec("init", dagger.TerragruntTfExecOpts{
+			Source: m.getTestDir("").
+				Directory("terraform"),
+		})
+
+	tfPlanCtr := tgModule.WithContainer(tfInitCtr).
+		TfExec("plan")
+
+	// Evaluate the terraform init command.
+	tfPlanOut, tfPlanErr := tfPlanCtr.WithExec([]string{"ls"}).Terminal().
+		Stdout(ctx)
+
+	if tfPlanErr != nil {
+		return WrapErrorf(tfPlanErr, "failed to get terraform plan command output")
+	}
+
+	if tfPlanOut == "" {
+		return Errorf("terraform plan command output is empty")
+	}
+
+	// Check the environment variables set in the container
+	for _, envVar := range testEnvVars {
+		if err := m.assertEnvVarIsSetInContainer(ctx, tfPlanCtr, envVar); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/terragrunt/tests/terraform.go
+++ b/terragrunt/tests/terraform.go
@@ -39,14 +39,21 @@ func (m *Tests) TestTfExecInitSimpleCommand(ctx context.Context) error {
 	tfInitCtr := tgModule.
 		TfExec("init", dagger.TerragruntTfExecOpts{
 			Source: m.getTestDir("").
-				Directory("terraform"),
+				Directory("terraform/tf-module-1"),
 		})
 
-	tfPlanCtr := tgModule.WithContainer(tfInitCtr).
-		TfExec("plan")
+	tfPlanCtr := tfInitCtr.
+		WithExec([]string{"ls"}).
+		WithExec([]string{"terraform", "plan"})
+
+	// tfPlanCtr := tgModule.WithContainer(tfInitCtr).
+	// 	TfExec("plan", dagger.TerragruntTfExecOpts{
+	// 		Source: tfInitCtr.Directory("."),
+	// 	})
 
 	// Evaluate the terraform init command.
-	tfPlanOut, tfPlanErr := tfPlanCtr.WithExec([]string{"ls"}).Terminal().
+	tfPlanOut, tfPlanErr := tfPlanCtr.
+		Terminal().
 		Stdout(ctx)
 
 	if tfPlanErr != nil {


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ Add support for native command execution within the Dagger container.
* 🎉 Users can now execute Terraform or Terragrunt commands directly in the container, without the need for additional wrapper functions.

## 🤔 Why
* 💡 These changes were made to improve the flexibility and robustness of the tool's configuration handling, allowing users to execute a wider range of IaC commands.
* 🎯 This will enable users to perform more complex and tailored operations within the Dagger container, improving the overall usability and capabilities of the tool.

## 📚 References
* 🔗 This PR is part of the ongoing effort to enhance the tool's functionality, as outlined in the project's roadmap.