### PR TITLE
fix: Remove unnecessary -refresh=true option from Terragrunt plan command

### DIFF
--- a/terragrunt/tests/terragrunt.go
+++ b/terragrunt/tests/terragrunt.go
@@ -425,7 +425,6 @@ func (m *Tests) TestTerragruntExecWithPlanOutput(ctx context.Context) error {
 		// Args to output the plan to a file.
 		Args: []string{
 			"-out=plan.tfplan",
-			"-refresh=true",
 		},
 	})
 


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ Remove the unnecessary `-refresh=true` option from the Terragrunt plan command.
* 🎉 This will simplify the Terragrunt plan command and remove an unnecessary option.

## 🤔 Why
Explain why the changes are necessary:
* 💡 The `-refresh=true` option is not required for the Terragrunt plan command, as Terragrunt will automatically refresh the state before running the plan.
* 🎯 Removing this unnecessary option will make the Terragrunt plan command more concise and easier to read.

## 📚 References
Link any supporting context or documentation:
* 🔗 This change is based on the commit message: "fix: Remove unnecessary -refresh=true option from Terragrunt plan command".