### PR TITLE
feat: Update Go version to 1.21 in tests

### DIFF
--- a/.daggerx/templates/mod-full/tests/golang.go.tmpl
+++ b/.daggerx/templates/mod-full/tests/golang.go.tmpl
@@ -625,7 +625,7 @@ func (m *Tests) TestGoWithGCCCompiler(ctx context.Context) error {
 func (m *Tests) TestGoWithGoTestSum(ctx context.Context) error {
 	baseModule := dag.{{.module_name}}(
 		dagger.{{.module_name}}Opts{
-			Ctr: getGolangAlpineContainer("1.20.4"),
+			Ctr: getGolangAlpineContainer("1.21"),
 		},
 	)
 

--- a/module-template/tests/golang.go
+++ b/module-template/tests/golang.go
@@ -625,7 +625,7 @@ func (m *Tests) TestGoWithGCCCompiler(ctx context.Context) error {
 func (m *Tests) TestGoWithGoTestSum(ctx context.Context) error {
 	baseModule := dag.ModuleTemplate(
 		dagger.ModuleTemplateOpts{
-			Ctr: getGolangAlpineContainer("1.20.4"),
+			Ctr: getGolangAlpineContainer("1.21"),
 		},
 	)
 


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ The changes update the Go version used in the `TestGoWithGoTestSum` test from 1.20.4 to 1.21.
* 🎉 This ensures the tests are running with the latest stable version of Go.

## 🤔 Why
Explain why the changes are necessary:
* 💡 The changes were made to update the Go version used in the tests to the latest stable version.
* 🎯 This will help ensure the tests are running with the most up-to-date version of Go, which can provide performance improvements and bug fixes.

## 📚 References
Link any supporting context or documentation:
* 🔗 None