### PR TITLE
fix: Update Dagger version to v6 in CI workflows

### DIFF
--- a/.github/workflows/ci-mod-module-template-light.yaml
+++ b/.github/workflows/ci-mod-module-template-light.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Dagger Develop on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light
@@ -48,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/tests
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Examples Module for Go 📄 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/examples/go
@@ -67,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Dagger Call on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template-light
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Call on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template-light/tests
@@ -85,7 +85,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Call on Test Examples/Go Module 📄 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template-light/examples/go
@@ -108,7 +108,7 @@ jobs:
 
       # Dagger main module 📦 (develop & golang ci-lint)
       - name: Dagger Develop on Module 📦 module-template-light with Dagger ${{ env.DAGGER_VERSION }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light
@@ -129,7 +129,7 @@ jobs:
 
       # Dagger test module 🧪 (develop & golang ci-lint)
       - name: Dagger Develop on Module tests 🧪 module-template-light with Dagger ${{ env.DAGGER_VERSION }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/tests
@@ -145,7 +145,7 @@ jobs:
 
       # Dagger examples (go) module 📄 (develop & golang ci-lint)
       - name: Dagger Develop on Module Examples/Go 📄 module-template-light with Dagger ${{ env.DAGGER_VERSION }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/examples/go
@@ -173,7 +173,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Dagger Develop on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light
@@ -182,7 +182,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/tests
@@ -191,7 +191,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Running Tests 💣 in module-template-light on ${{ matrix.go }} with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           args: test-all
@@ -215,7 +215,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Dagger Develop on Module Examples 📄
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template-light/examples/go
@@ -224,7 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Running Recipes all recipes 💣 in module-template-light/examples/go
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           args: all-recipes

--- a/.github/workflows/ci-mod-module-template.yaml
+++ b/.github/workflows/ci-mod-module-template.yaml
@@ -17,12 +17,13 @@ permissions:
   pull-requests: read
   checks: write
 
+env:
+  DAGGER_VERSION_EXAMPLES_GO: 0.14.0
+  DAGGER_VERSION: 0.14.0
+
 defaults:
   run:
     working-directory: module-template
-
-env:
-  DAGGER_VERSION_EXAMPLES_GO: 0.14.0
 
 jobs:
   dagger-linter:
@@ -38,7 +39,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Dagger Develop on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template
@@ -47,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/tests
@@ -56,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Examples Module for Go 📄 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/examples/go
@@ -66,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Dagger Call on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template
@@ -75,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Call on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template/tests
@@ -84,7 +85,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Call on Test Examples/Go Module 📄 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           module: module-template/examples/go
@@ -106,12 +107,12 @@ jobs:
           go-version: ${{ matrix.go }}
 
       # Dagger main module 📦 (develop & golang ci-lint)
-      - name: Dagger Develop on Module 📦 module-template with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+      - name: Dagger Develop on Module 📦 module-template with Dagger ${{ env.DAGGER_VERSION }}
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template
-          version: ${{ matrix.dagversion }}
+          version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,12 +128,12 @@ jobs:
           golangci-lint run --config=../.golangci.yml --verbose
 
       # Dagger test module 🧪 (develop & golang ci-lint)
-      - name: Dagger Develop on Module tests 🧪 module-template with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+      - name: Dagger Develop on Module tests 🧪 module-template with Dagger ${{ env.DAGGER_VERSION }}
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/tests
-          version: ${{ matrix.dagversion }}
+          version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,12 +144,12 @@ jobs:
           golangci-lint run --config=../../.golangci.yml --verbose
 
       # Dagger examples (go) module 📄 (develop & golang ci-lint)
-      - name: Dagger Develop on Module Examples/Go 📄 module-template with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+      - name: Dagger Develop on Module Examples/Go 📄 module-template with Dagger ${{ env.DAGGER_VERSION }}
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/examples/go
-          version: ${{ matrix.dagversion }}
+          version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +173,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Dagger Develop on Module 📦 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template
@@ -181,7 +182,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dagger Develop on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/tests
@@ -190,7 +191,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Running Tests 💣 in module-template on ${{ matrix.go }} with Dagger ${{ matrix.dagversion }}
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           args: test-all
@@ -214,7 +215,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Dagger Develop on Module Examples 📄
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: develop
           module: module-template/examples/go
@@ -223,7 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Running Recipes all recipes 💣 in module-template/examples/go
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v6
         with:
           verb: call
           args: all-recipes


### PR DESCRIPTION
## 🎯 What
* ❓ The changes in this PR update the Dagger version used in the CI workflows from v7 to v6.
* 🎉 This ensures the CI workflows continue to function correctly with the current version of Dagger.

## 🤔 Why
* 💡 The changes are made to address a compatibility issue with the latest version of Dagger.
* 🎯 This will allow the CI workflows to continue running without any issues.

## 📚 References
* 🔗 This PR is related to the compatibility issue with the latest version of Dagger.