### PR TITLE
ci: Update CI workflows for module templates

### DIFF
--- a/.github/workflows/ci-mod-module-template-light.yaml
+++ b/.github/workflows/ci-mod-module-template-light.yaml
@@ -69,7 +69,8 @@ jobs:
       - name: Dagger Call on Module 📦 with Dagger ${{ matrix.dagversion }}
         uses: dagger/dagger-for-github@v6
         with:
-          verb: call
+          # Default, it should list all the functions.
+          call:
           module: module-template-light
           version: ${{ matrix.dagversion }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
@@ -78,7 +79,8 @@ jobs:
       - name: Dagger Call on Test Module 🧪 with Dagger ${{ matrix.dagversion }}
         uses: dagger/dagger-for-github@v6
         with:
-          verb: call
+          # Default, it should list all the functions.
+          call:
           module: module-template-light/tests
           version: ${{ matrix.dagversion }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
@@ -87,7 +89,8 @@ jobs:
       - name: Dagger Call on Test Examples/Go Module 📄 with Dagger ${{ matrix.dagversion }}
         uses: dagger/dagger-for-github@v6
         with:
-          verb: call
+          # Default, it should list all the functions.
+          call:
           module: module-template-light/examples/go
           version: ${{ matrix.dagversion }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/ci-mod-templates.yaml
+++ b/.github/workflows/ci-mod-templates.yaml
@@ -1,0 +1,150 @@
+name: CI Templates 🧰
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "module-template/**"
+      - "module-template-light/**"
+  pull_request:
+    paths:
+      - "module-template/**"
+      - "module-template-light/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+env:
+  GO_VERSION: "1.22"
+  DAGGER_VERSION: "0.14.0"
+
+jobs:
+  dagger-build:
+    strategy:
+      matrix:
+        module: [module-template, module-template-light]
+        dagger-version: [0.13.7, 0.14.0]
+      fail-fast: true
+    name: 🏗️ Build ${{ matrix.module }} with Dagger ${{ matrix.dagger-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: 📦 Dagger Develop Main Module
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: develop
+          module: ${{ matrix.module }}
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🧪 Dagger Develop Test Module
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: develop
+          module: ${{ matrix.module }}/tests
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📄 Dagger Develop Examples Module
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: develop
+          module: ${{ matrix.module }}/examples/go
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dagger-call:
+    needs: dagger-build
+    strategy:
+      matrix:
+        module: [module-template, module-template-light]
+        dagger-version: [0.13.7, 0.14.0]
+      fail-fast: false
+    name: 📞 Call Functions in ${{ matrix.module }} with Dagger ${{ matrix.dagger-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: 📦 List Main Module Functions
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: call
+          module: ${{ matrix.module }}
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🧪 List Test Module Functions
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: call
+          module: ${{ matrix.module }}/tests
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📄 List Example Module Functions
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: call
+          module: ${{ matrix.module }}/examples/go
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-tests:
+    needs: dagger-build
+    strategy:
+      matrix:
+        module: [module-template, module-template-light]
+        dagger-version: [0.13.7, 0.14.0]
+      fail-fast: false
+    name: 🧪 Run Tests for ${{ matrix.module }} with Dagger ${{ matrix.dagger-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: 💣 Run All Tests
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: call
+          args: test-all
+          module: ${{ matrix.module }}/tests
+          version: ${{ matrix.dagger-version }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🥗 Run All Example Recipes with Dagger ${{ env.DAGGER_VERSION }}
+        uses: dagger/dagger-for-github@v6
+        with:
+          verb: call
+          args: all-recipes
+          module: ${{ matrix.module }}/examples/go
+          version: ${{ env.DAGGER_VERSION }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ The changes in this PR update the CI workflows for the module-template and module-template-light projects.
* 🎉 These updates will improve the reliability and maintainability of the CI workflows for the module template projects.

## 🤔 Why
* 💡 The changes were made to standardize the "verb" parameter in the dagger-for-github action, add comments to clarify the "call" action, update the matrix strategy to include both Dagger versions 0.13.7 and 0.14.0 for testing, and ensure the CI workflows run on both the main and master branches, as well as when changes are made to the module-template and module-template-light directories.
* 🎯 These improvements will help ensure the CI workflows for the module template projects are more consistent, reliable, and maintainable.

## 📚 References
* 🔗 This PR is related to the changes described in the commit messages.