### PR TITLE
ci: Simplify job names in CI workflows

### DIFF
--- a/.github/workflows/ci-mod-templates.yaml
+++ b/.github/workflows/ci-mod-templates.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         module: [module-template, module-template-light]
       fail-fast: true
-    name: 🏗️ Build ${{ matrix.module }} with Dagger ${{ env.DAGGER_VERSION }}
+    name: 🏗️ Build ${{ matrix.module }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
       matrix:
         module: [module-template, module-template-light]
       fail-fast: false
-    name: 📞 Call Functions in ${{ matrix.module }} with Dagger ${{ env.DAGGER_VERSION }}
+    name: 📞 Call Functions in ${{ matrix.module }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
       matrix:
         module: [module-template, module-template-light]
       fail-fast: false
-    name: 🧪 Run Tests for ${{ matrix.module }} with Dagger ${{ env.DAGGER_VERSION }}
+    name: 🧪 Run Tests for ${{ matrix.module }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
       matrix:
         module: [module-template, module-template-light]
       fail-fast: false
-    name: 🥗 Run Recipes for ${{ matrix.module }} with Dagger ${{ env.DAGGER_VERSION }}
+    name: 🥗 Run Recipes for ${{ matrix.module }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ The changes in this PR simplify the job names in the CI workflows for the module templates. The job names no longer include the Dagger version, as this information is not necessary for the job descriptions.
* 🎉 This makes the job names more concise and easier to read, while still providing the necessary information about the module being built or tested.

## 🤔 Why
* 💡 The changes were made to simplify the job names in the CI workflows and remove unnecessary information.
* 🎯 This will make the CI workflows more readable and maintainable, without losing any important details.

## 📚 References
* 🔗 The changes are described in the commit message: [ci: Simplify job names in CI workflows](https://github.com/your-repo/commit/abcd1234)