### PR TITLE
ci: Update Dagger workflow to use correct workdir

### DIFF
--- a/.github/workflows/ci-mod-templates.yaml
+++ b/.github/workflows/ci-mod-templates.yaml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  dagger-call:
+  dagger-list-functions:
     needs: dagger-build
     strategy:
       matrix:
@@ -84,7 +84,7 @@ jobs:
         uses: dagger/dagger-for-github@v6
         with:
           verb: call
-          module: ${{ matrix.module }}
+          workdir: ${{ matrix.module }}
           version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
@@ -94,7 +94,7 @@ jobs:
         uses: dagger/dagger-for-github@v6
         with:
           verb: call
-          module: ${{ matrix.module }}/tests
+          workdir: ${{ matrix.module }}/tests
           version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
@@ -104,7 +104,7 @@ jobs:
         uses: dagger/dagger-for-github@v6
         with:
           verb: call
-          module: ${{ matrix.module }}/examples/go
+          workdir: ${{ matrix.module }}/examples/go
           version: ${{ env.DAGGER_VERSION }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ The changes in this commit update the Dagger workflow to use the correct `workdir` parameter instead of the `module` parameter.
* 🎉 This ensures that the Dagger commands are executed in the correct directory for the examples, tests, and main module.

## 🤔 Why
Explain why the changes are necessary:
* 💡 The changes were made to ensure that the Dagger workflow is using the correct directory for executing the commands.
* 🎯 This will help to ensure that the examples, tests, and main module are all executed in the correct context, improving the reliability and consistency of the CI/CD pipeline.

## 📚 References
Link any supporting context or documentation:
* 🔗 N/A