### PR TITLE
fix: missing packages in go test command

### DIFF
--- a/gotest/gotestcmd.go
+++ b/gotest/gotestcmd.go
@@ -434,6 +434,7 @@ func (m *Gotest) RunTest(
 
 	cmdToAppend = append(cmdToAppend, buildOpts.Flags...)
 	cmdToAppend = append(cmdToAppend, testOptions.Flags...)
+	cmdToAppend = append(cmdToAppend, packages...)
 
 	if envVars != nil {
 		if err := m.setupEnvironmentVariables(envVars); err != nil {


### PR DESCRIPTION
## 🎯 What

- ❓ Adds missing packages parameter to `go test` command
- 🎉 Users can recursively run tests using `dagger call run-test --source="." --packages="./..."`

## 🤔 Why

- 💡 The packages parameter is not being passed, causing `go test` to fail if the tests are not in the root directory of `source`
